### PR TITLE
changing image tag GITHUB_ENV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,7 +233,7 @@ jobs:
 
       - name: Prepare Docker environment
         run: |
-          echo IMAGE_TAG=$(if [ "$GITHUB_REF" == "refs/heads/main" ]; then echo "main-${GITHUB_SHA::7}"; else echo "$GITHUB_REF_NAME"; fi) >> $GITHUB_ENV
+          echo IMAGE_TAG=$(if [ -n "$GITHUB_REF_NAME" ]; then echo "$GITHUB_REF_NAME"; else echo "main-${GITHUB_SHA::7}"; fi) >> $GITHUB_ENV
           echo PUSH_IMAGE=true >> $GITHUB_ENV
           echo "Docker image will be published with the tag: ${{ env.IMAGE_TAG }}!"
           chmod +x ./artifacts/polkadot-staking-miner


### PR DESCRIPTION
issue https://github.com/paritytech/polkadot-staking-miner/issues/746

> GITHUB_REF_NAME	The short ref name of the branch or tag that triggered the workflow run. This value matches the branch or tag name shown on GitHub. For example, feature-branch-1.

> For pull requests, the format is refs/pull/<pr_number>/merge.