### PR TITLE
fix(ci): update rustc to build polkadot

### DIFF
--- a/.github/workflows/build-polkadot-for-nightly.yml
+++ b/.github/workflows/build-polkadot-for-nightly.yml
@@ -11,7 +11,7 @@ jobs:
   tests:
     name: Build polkadot binary
     runs-on: ubuntu-latest
-    container: ci-unified:bullseye-1.77.0-2024-04-10-v20240408
+    container: paritytech/ci-unified:bullseye-1.77.0-2024-04-10-v20240408
     steps:
       - name: checkout polkadot-sdk
         uses: actions/checkout@v4

--- a/.github/workflows/build-polkadot-for-nightly.yml
+++ b/.github/workflows/build-polkadot-for-nightly.yml
@@ -11,7 +11,7 @@ jobs:
   tests:
     name: Build polkadot binary
     runs-on: ubuntu-latest
-    container: paritytech/ci-unified:bullseye-1.74.0-2023-11-01-v20231204
+    container: ci-unified:bullseye-1.77.0-2024-04-10-v20240408
     steps:
       - name: checkout polkadot-sdk
         uses: actions/checkout@v4

--- a/.github/workflows/build-staking-miner-playground-for-nightly.yml
+++ b/.github/workflows/build-staking-miner-playground-for-nightly.yml
@@ -17,7 +17,7 @@ jobs:
   tests:
     name: Build staking-miner-playground
     runs-on: ubuntu-latest
-    container: paritytech/ci-unified:bullseye-1.74.0-2023-11-01-v20231204
+    container: paritytech/ci-unified:bullseye-1.77.0-2024-04-10-v20240408
     steps:
       - name: checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
       - main
 
 env:
-  IMAGE: paritytech/ci-unified:bullseye-1.74.0-2023-11-01-v20231204
+  IMAGE: paritytech/ci-unified:bullseye-1.77.0-2024-04-10-v20240408
   IMAGE_NAME: paritytech/polkadot-staking-miner
   RUST_INFO: rustup show && cargo --version && rustup +nightly show && cargo +nightly --version
 


### PR DESCRIPTION
This job fails: https://github.com/paritytech/polkadot-staking-miner/actions/runs/8961429706/job/24609041671#step:5:17 which will be fixed by updating rustc

Close https://github.com/paritytech/polkadot-staking-miner/issues/823