### PR TITLE
ci: bump rust to v1.81

### DIFF
--- a/.github/workflows/build-polkadot-for-nightly.yml
+++ b/.github/workflows/build-polkadot-for-nightly.yml
@@ -11,7 +11,7 @@ jobs:
   tests:
     name: Build polkadot binary
     runs-on: ubuntu-latest
-    container: paritytech/ci-unified:bullseye-1.77.0-2024-04-10-v20240408
+    container: paritytech/ci-unified:bullseye-1.81.0-2024-09-11
     steps:
       - name: checkout polkadot-sdk
         uses: actions/checkout@v4

--- a/.github/workflows/build-staking-miner-playground-for-nightly.yml
+++ b/.github/workflows/build-staking-miner-playground-for-nightly.yml
@@ -17,7 +17,7 @@ jobs:
   tests:
     name: Build staking-miner-playground
     runs-on: ubuntu-latest
-    container: paritytech/ci-unified:bullseye-1.77.0-2024-04-10-v20240408
+    container: paritytech/ci-unified:bullseye-1.81.0-2024-09-11
     steps:
       - name: checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
       - main
 
 env:
-  IMAGE: paritytech/ci-unified:bullseye-1.77.0-2024-04-10-v20240408
+  IMAGE: paritytech/ci-unified:bullseye-1.81.0-2024-09-11
   IMAGE_NAME: paritytech/polkadot-staking-miner
   RUST_INFO: rustup show && cargo --version && rustup +nightly show && cargo +nightly --version
 

--- a/.github/workflows/staking-miner-playground.yml
+++ b/.github/workflows/staking-miner-playground.yml
@@ -8,7 +8,7 @@ on:
       - 'staking-miner-playground/**'
 
 env:
-  IMAGE: paritytech/ci-unified:bullseye-1.77.0-2024-04-10-v20240408
+  IMAGE: paritytech/ci-unified:bullseye-1.81.0-2024-09-11
   IMAGE_NAME: paritytech/polkadot-staking-miner
   RUST_INFO: rustup show && cargo --version && rustup +nightly show && cargo +nightly --version
 

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -115,8 +115,8 @@ pub fn kill_main_task_if_critical_err(tx: &tokio::sync::mpsc::UnboundedSender<Er
 							// It's possible to get other errors such as outdated nonce and similar
 							// but then it should be possible to try again in the next block or round.
 							if e.code() == BAD_EXTRINSIC_FORMAT ||
-								e.code() == VERIFICATION_ERROR || e.code() ==
-								ErrorCode::MethodNotFound.code()
+								e.code() == VERIFICATION_ERROR ||
+								e.code() == ErrorCode::MethodNotFound.code()
 							{
 								let _ = tx.send(Error::Subxt(SubxtError::Rpc(
 									RpcError::ClientError(Box::new(JsonRpseeError::Call(e))),


### PR DESCRIPTION
This fixes [the polkadot binary build](https://github.com/paritytech/polkadot-staking-miner/actions/runs/11134157706/job/30941796735) which failed because the `LazyLock` was stabilized in rust v1.80 