### PR TITLE
remove `subxt substrate-compat` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,10 +25,10 @@ pin-project-lite = "0.2"
 
 # subxt
 scale-value = "0.17"
-subxt = { version = "0.38.0", features = ["substrate-compat"] }
+subxt = "0.38.0"
 
 # polkadot-sdk
-polkadot-sdk = { version = "0.7", features = ["frame-election-provider-support", "frame-support", "sp-npos-elections", "sp-runtime", "pallet-election-provider-multi-phase"] }
+polkadot-sdk = { version = "0.7", features = ["frame-election-provider-support", "frame-support", "sp-npos-elections", "sp-core", "sp-runtime", "pallet-election-provider-multi-phase"] }
 
 # prometheus
 prometheus = "0.13"

--- a/src/commands/emergency_solution.rs
+++ b/src/commands/emergency_solution.rs
@@ -21,7 +21,7 @@ use crate::{
 };
 use clap::Parser;
 use codec::Encode;
-use sp_core::hexdisplay::HexDisplay;
+use polkadot_sdk::sp_core::hexdisplay::HexDisplay;
 use std::io::Write;
 use subxt::tx::Payload;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,8 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::prelude::*;
-
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
 	#[error("Failed to parse log directive: `{0}´")]
@@ -27,7 +25,7 @@ pub enum Error {
 	#[error("subxt error: `{0}`")]
 	Subxt(#[from] subxt::Error),
 	#[error("Crypto error: `{0:?}`")]
-	Crypto(sp_core::crypto::SecretStringError),
+	Crypto(polkadot_sdk::sp_core::crypto::SecretStringError),
 	#[error("Codec error: `{0}`")]
 	Codec(#[from] codec::Error),
 	#[error("Incorrect phase")]

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -21,8 +21,10 @@
 //! needing to sprinkle `any_runtime` in a few extra places.
 
 // re-exports.
-pub use polkadot_sdk::pallet_election_provider_multi_phase::{Miner, MinerConfig};
-pub use subxt::ext::sp_core;
+pub use polkadot_sdk::{
+	pallet_election_provider_multi_phase::{Miner, MinerConfig},
+	sp_runtime::traits::{Block as BlockT, Header as HeaderT},
+};
 /// The account id type.
 pub type AccountId = polkadot_sdk::sp_runtime::AccountId32;
 /// The header type. We re-export it here, but we can easily get it from block as well.
@@ -32,7 +34,6 @@ pub type Header =
 pub type Hash = subxt::utils::H256;
 /// Balance type
 pub type Balance = u128;
-pub use subxt::ext::sp_runtime::traits::{Block as BlockT, Header as HeaderT};
 
 /// Default URI to connect to.
 ///
@@ -42,20 +43,16 @@ pub const DEFAULT_URI: &str = "ws://127.0.0.1:9944";
 pub const DEFAULT_PROMETHEUS_PORT: u16 = 9999;
 /// The logging target.
 pub const LOG_TARGET: &str = "polkadot-staking-miner";
-
 /// The key pair type being used. We "strongly" assume sr25519 for simplicity.
-pub type Pair = sp_core::sr25519::Pair;
-
-/// The accuracy that we use for election computation.
+pub type Pair = polkadot_sdk::sp_core::sr25519::Pair;
+/// The accuracy that we use for election computations.
 pub type Accuracy = polkadot_sdk::sp_runtime::Perbill;
-
+/// RPC client.
 pub type RpcClient = subxt::backend::legacy::LegacyRpcMethods<subxt::PolkadotConfig>;
 /// Subxt client used by the staking miner on all chains.
 pub type ChainClient = subxt::OnlineClient<subxt::PolkadotConfig>;
-
 /// Config used by the staking-miner
 pub type Config = subxt::PolkadotConfig;
-
 /// Submission type used by the staking miner.
 pub type SignedSubmission<S> =
 	polkadot_sdk::pallet_election_provider_multi_phase::SignedSubmission<AccountId, Balance, S>;

--- a/src/signer.rs
+++ b/src/signer.rs
@@ -16,30 +16,62 @@
 
 //! Wrappers around creating a signer account.
 
-use crate::{error::Error, prelude::*};
-use sp_core::Pair as _;
+use crate::{
+	error::Error,
+	prelude::{Config as PolkadotConfig, Pair},
+};
+use polkadot_sdk::{
+	sp_core::Pair as PairT,
+	sp_runtime::{
+		traits::{IdentifyAccount, Verify},
+		MultiSignature as SpMultiSignature,
+	},
+};
+use subxt::Config;
 
-// A signer type, parameterized for using with `subxt`.
-pub type PairSigner = subxt::tx::PairSigner<subxt::PolkadotConfig, sp_core::sr25519::Pair>;
-
-// Signer wrapper.
-//
-// NOTE: both `Pair` and `PairSigner` are stored here so it can be cloned
-// which is hack around that PairSigner !Clone.
-pub struct Signer {
-	pair: Pair,
-	signer: PairSigner,
+/// A [`Signer`] implementation that can be constructed from an [`sp_core::Pair`].
+#[derive(Clone)]
+pub struct PairSigner {
+	account_id: <PolkadotConfig as Config>::AccountId,
+	signer: Pair,
 }
 
-impl std::fmt::Display for Signer {
-	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-		write!(f, "{}", self.signer.account_id())
+impl PairSigner {
+	/// Creates a new [`Signer`] from an [`sp_core::Pair`].
+	pub fn new(signer: Pair) -> Self {
+		let account_id = <SpMultiSignature as Verify>::Signer::from(signer.public()).into_account();
+		let subxt_account_id = subxt::config::substrate::AccountId32(account_id.into());
+		Self { account_id: subxt_account_id, signer }
+	}
+
+	/// Return the account ID.
+	pub fn account_id(&self) -> &<PolkadotConfig as Config>::AccountId {
+		&self.account_id
 	}
 }
 
-impl Clone for Signer {
-	fn clone(&self) -> Self {
-		Self { pair: self.pair.clone(), signer: PairSigner::new(self.pair.clone()) }
+impl subxt::tx::Signer<PolkadotConfig> for PairSigner {
+	fn account_id(&self) -> <PolkadotConfig as Config>::AccountId {
+		self.account_id.clone()
+	}
+
+	fn address(&self) -> <PolkadotConfig as Config>::Address {
+		self.account_id.clone().into()
+	}
+
+	fn sign(&self, signer_payload: &[u8]) -> <PolkadotConfig as Config>::Signature {
+		let signature = self.signer.sign(signer_payload);
+		subxt::config::substrate::MultiSignature::Sr25519(signature.0)
+	}
+}
+
+// Signer wrapper.
+#[derive(Clone)]
+pub struct Signer(PairSigner);
+
+impl std::fmt::Display for Signer {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		write!(f, "{}", self.0.account_id())
 	}
 }
 
@@ -54,9 +86,9 @@ impl Signer {
 
 		let seed = seed.trim();
 		let pair = Pair::from_string(seed, None).map_err(Error::Crypto)?;
-		let signer = PairSigner::new(pair.clone());
+		let signer = PairSigner::new(pair);
 
-		Ok(Self { pair, signer })
+		Ok(Self(signer))
 	}
 }
 
@@ -64,12 +96,12 @@ impl std::ops::Deref for Signer {
 	type Target = PairSigner;
 
 	fn deref(&self) -> &Self::Target {
-		&self.signer
+		&self.0
 	}
 }
 
 impl std::ops::DerefMut for Signer {
 	fn deref_mut(&mut self) -> &mut Self::Target {
-		&mut self.signer
+		&mut self.0
 	}
 }

--- a/src/signer.rs
+++ b/src/signer.rs
@@ -29,7 +29,7 @@ use polkadot_sdk::{
 };
 use subxt::Config;
 
-/// A [`Signer`] implementation that can be constructed from an [`sp_core::Pair`].
+/// A [`Signer`] implementation that can be constructed from an [`polkadot_sdk::sp_core::Pair`].
 #[derive(Clone)]
 pub struct PairSigner {
 	account_id: <PolkadotConfig as Config>::AccountId,
@@ -37,7 +37,7 @@ pub struct PairSigner {
 }
 
 impl PairSigner {
-	/// Creates a new [`Signer`] from an [`sp_core::Pair`].
+	/// Creates a new [`Signer`] from an [`Pair`].
 	pub fn new(signer: Pair) -> Self {
 		let account_id = <SpMultiSignature as Verify>::Signer::from(signer.public()).into_account();
 		let subxt_account_id = subxt::config::substrate::AccountId32(account_id.into());

--- a/src/signer.rs
+++ b/src/signer.rs
@@ -29,7 +29,7 @@ use polkadot_sdk::{
 };
 use subxt::Config;
 
-/// A [`Signer`] implementation that can be constructed from an [`polkadot_sdk::sp_core::Pair`].
+/// A [`Signer`] implementation that can be constructed from an [`Pair`].
 #[derive(Clone)]
 pub struct PairSigner {
 	account_id: <PolkadotConfig as Config>::AccountId,


### PR DESCRIPTION
This replaces `subxt substrate compat feature` with our own `PairSigner` to avoid depending on different versions of sp-core.