### PR TITLE
ci: Upgrade actions/upload-artifact and actions/download-artifact to v4

### DIFF
--- a/.github/workflows/build-polkadot-for-nightly.yml
+++ b/.github/workflows/build-polkadot-for-nightly.yml
@@ -34,7 +34,7 @@ jobs:
           strip -s ./target/release/polkadot-execute-worker
 
       - name: upload polkadot binary
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: nightly-polkadot-binary
           path: |

--- a/.github/workflows/build-staking-miner-playground-for-nightly.yml
+++ b/.github/workflows/build-staking-miner-playground-for-nightly.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - main
     paths:
-      - 'staking-miner-playground/**'
+      - "staking-miner-playground/**"
   # Allow it to be manually ran to rebuild binary when needed:
   workflow_dispatch: {}
   # Run at 22pm every week on Mondays for nightly builds.
@@ -37,7 +37,7 @@ jobs:
           strip -s ./target/release/staking-miner-playground
 
       - name: upload staking-miner-playground binary
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: staking-miner-playground-binary
           path: ./staking-miner-playground/target/release/staking-miner-playground

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
         run: mv ./target/release/polkadot-staking-miner .
 
       - name: Collect artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build-artifacts
           path: |
@@ -158,18 +158,13 @@ jobs:
     name: Test Docker image build
     if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
-    needs: [check-fmt,
-            check-clippy,
-            check-docs,
-            check-cargo-hack,
-            test,
-            build]
+    needs: [check-fmt, check-clippy, check-docs, check-cargo-hack, test, build]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-artifacts
           path: ./artifacts
@@ -197,18 +192,13 @@ jobs:
     if: ${{ github.ref == 'refs/heads/main' ||  github.ref_type == 'tag' }}
     runs-on: ubuntu-latest
     environment: main_and_tags
-    needs: [check-fmt,
-            check-clippy,
-            check-docs,
-            check-cargo-hack,
-            test,
-            build]
+    needs: [check-fmt, check-clippy, check-docs, check-cargo-hack, test, build]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-artifacts
           path: ./artifacts


### PR DESCRIPTION
Artifact actions v3 will be deprecated by December 5, 2024, updating them.

cc https://github.com/paritytech/ci_cd/issues/1078