### PR TITLE
multi block miner: do_reduce configurable via CLI (#995)

### DIFF
--- a/src/commands/multi_block/monitor.rs
+++ b/src/commands/multi_block/monitor.rs
@@ -134,6 +134,7 @@ where
                 config.listen,
                 submit_lock,
                 config.submission_strategy,
+                config.do_reduce,
             )
             .await
             {
@@ -163,6 +164,7 @@ async fn process_block<T>(
     listen: Listen,
     submit_lock: Arc<Mutex<()>>,
     submission_strategy: SubmissionStrategy,
+    do_reduce: bool,
 ) -> Result<(), Error>
 where
     T: MinerConfig<AccountId = AccountId> + Send + Sync + 'static,
@@ -230,6 +232,7 @@ where
         round,
         desired_targets,
         block_number,
+        do_reduce,
     )
     .timed()
     .await

--- a/src/commands/types.rs
+++ b/src/commands/types.rs
@@ -181,4 +181,7 @@ pub struct ExperimentalMultiBlockMonitorConfig {
 
     #[clap(long, value_parser, default_value = "if-leading")]
     pub submission_strategy: SubmissionStrategy,
+
+    #[clap(long, default_value_t = false)]
+    pub do_reduce: bool,
 }

--- a/src/commands/types.rs
+++ b/src/commands/types.rs
@@ -182,6 +182,7 @@ pub struct ExperimentalMultiBlockMonitorConfig {
     #[clap(long, value_parser, default_value = "if-leading")]
     pub submission_strategy: SubmissionStrategy,
 
+    /// Reduce the solution to prevent further trimming.
     #[clap(long, default_value_t = false)]
     pub do_reduce: bool,
 }

--- a/src/dynamic/multi_block.rs
+++ b/src/dynamic/multi_block.rs
@@ -186,6 +186,7 @@ pub(crate) async fn mine_solution<T>(
     round: u32,
     desired_targets: u32,
     block_number: u32,
+    do_reduce: bool,
 ) -> Result<PagedRawSolution<T>, Error>
 where
     T: MinerConfig<AccountId = AccountId> + Send + Sync + 'static,
@@ -207,7 +208,7 @@ where
 
     log::trace!(
         target: LOG_TARGET,
-        "MineInput: desired_targets={desired_targets},pages={n_pages},target_snapshot_len={},voters_pages_len={},do_reduce=false,round={round},at={block_number}",
+        "MineInput: desired_targets={desired_targets},pages={n_pages},target_snapshot_len={},voters_pages_len={},do_reduce={do_reduce},round={round},at={block_number}",
         target_snapshot.len(), voter_pages.len()
     );
 
@@ -216,8 +217,7 @@ where
         all_targets: target_snapshot.clone(),
         voter_pages: voter_pages.clone(),
         pages: n_pages,
-        // TODO: https://github.com/paritytech/polkadot-staking-miner/issues/995
-        do_reduce: false,
+        do_reduce,
         round,
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -368,4 +368,61 @@ mod tests {
             }
         );
     }
+
+    #[test]
+    fn cli_experimental_monitor_multi_block_works() {
+        let opt = Opt::try_parse_from([
+            env!("CARGO_PKG_NAME"),
+            "--uri",
+            "hi",
+            "experimental-monitor-multi-block",
+            "--seed-or-path",
+            "//Alice",
+            "--do-reduce",
+        ])
+        .unwrap();
+
+        assert_eq!(
+            opt,
+            Opt {
+                uri: "hi".to_string(),
+                prometheus_port: 9999,   // Assuming default
+                log: "info".to_string(), // Assuming default
+                command: Command::ExperimentalMonitorMultiBlock(
+                    commands::types::ExperimentalMultiBlockMonitorConfig {
+                        seed_or_path: "//Alice".to_string(),
+                        listen: Listen::Finalized, // Assuming default
+                        submission_strategy: SubmissionStrategy::IfLeading, // Assuming default
+                        do_reduce: true,           // Expect true because flag was present
+                    }
+                ),
+            }
+        );
+    }
+
+    #[test]
+    fn cli_experimental_monitor_multi_block_default_works() {
+        let opt = Opt::try_parse_from([
+            env!("CARGO_PKG_NAME"),
+            "--uri",
+            "hi",
+            "experimental-monitor-multi-block",
+            "--seed-or-path",
+            "//Alice",
+            // No --do-reduce flag
+        ])
+        .unwrap();
+
+        assert_eq!(
+            opt.command,
+            Command::ExperimentalMonitorMultiBlock(
+                commands::types::ExperimentalMultiBlockMonitorConfig {
+                    seed_or_path: "//Alice".to_string(),
+                    listen: Listen::Finalized,
+                    submission_strategy: SubmissionStrategy::IfLeading,
+                    do_reduce: false, // Expect false (default)
+                }
+            )
+        );
+    }
 }


### PR DESCRIPTION
Add the `--do-reduce` flag to the `experimental-monitor-multi-block` command.

This flag controls whether the reduction step is performed during the NPoS solution mining process for the multi-block election path.