### PR TITLE
Bump subxt to `0.41.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7454,7 +7454,6 @@ dependencies = [
  "serde",
  "serde_json",
  "subxt",
- "subxt-core 0.41.0",
  "subxt-rpcs",
  "thiserror 2.0.12",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3146,11 +3146,11 @@ dependencies = [
 
 [[package]]
 name = "frame-decode"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7af3d1149d6063985bb62d97f3ea83060ce4d6f2d04c21f551d270e8d84a27c"
+checksum = "50c554ce2394e2c04426a070b4cb133c72f6f14c86b665f4e13094addd8e8958"
 dependencies = [
- "frame-metadata 18.0.0",
+ "frame-metadata 20.0.0",
  "parity-scale-codec",
  "scale-decode 0.16.0",
  "scale-info",
@@ -3213,18 +3213,6 @@ dependencies = [
  "cfg-if",
  "parity-scale-codec",
  "scale-info",
-]
-
-[[package]]
-name = "frame-metadata"
-version = "18.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daaf440c68eb2c3d88e5760fe8c7af3f9fee9181fab6c2f2c4e7cc48dcc40bb8"
-dependencies = [
- "cfg-if",
- "parity-scale-codec",
- "scale-info",
- "serde",
 ]
 
 [[package]]
@@ -7466,7 +7454,8 @@ dependencies = [
  "serde",
  "serde_json",
  "subxt",
- "subxt-core 0.40.0",
+ "subxt-core 0.41.0",
+ "subxt-rpcs",
  "thiserror 2.0.12",
  "tokio",
  "tracing-subscriber",
@@ -8694,9 +8683,9 @@ dependencies = [
 
 [[package]]
 name = "scale-typegen"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc3173be608895eb117cf397ab4f31f00e2ed2c7af1c6e0b8f5d51d0a0967053"
+checksum = "6aebea322734465f39e4ad8100e1f9708c6c6c325d92b8780015d30c44fae791"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10239,17 +10228,16 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "subxt"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ffca95192207f6dbaf68a032f7915cfc8670f062df0464bdddf05d35a09bcf8"
+checksum = "03459d84546def5e1d0d22b162754609f18e031522b0319b53306f5829de9c09"
 dependencies = [
  "async-trait",
  "derive-where",
  "either",
- "frame-metadata 18.0.0",
+ "frame-metadata 20.0.0",
  "futures",
  "hex",
- "impl-serde",
  "jsonrpsee",
  "parity-scale-codec",
  "primitive-types 0.13.1",
@@ -10261,10 +10249,11 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "subxt-core 0.40.0",
+ "subxt-core 0.41.0",
  "subxt-lightclient",
  "subxt-macro",
- "subxt-metadata 0.40.0",
+ "subxt-metadata 0.41.0",
+ "subxt-rpcs",
  "thiserror 2.0.12",
  "tokio",
  "tokio-util",
@@ -10276,9 +10265,9 @@ dependencies = [
 
 [[package]]
 name = "subxt-codegen"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de8786ebc4be0905fac861c8ce1845e677a96b8ddb209e5c3e0e1f6b804d62f"
+checksum = "324c52c09919fec8c22a4b572a466878322e99fe14a9e3d50d6c3700a226ec25"
 dependencies = [
  "heck",
  "parity-scale-codec",
@@ -10286,7 +10275,7 @@ dependencies = [
  "quote",
  "scale-info",
  "scale-typegen",
- "subxt-metadata 0.40.0",
+ "subxt-metadata 0.41.0",
  "syn 2.0.100",
  "thiserror 2.0.12",
 ]
@@ -10322,15 +10311,15 @@ dependencies = [
 
 [[package]]
 name = "subxt-core"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daa812fea5d2a104d3253aa722daa51f222cf951304f4d47eda70c268bf99921"
+checksum = "66ef00be9d64885ec94e478a58e4e39d222024b20013ae7df4fc6ece545391aa"
 dependencies = [
  "base58",
  "blake2",
  "derive-where",
- "frame-decode 0.6.1",
- "frame-metadata 18.0.0",
+ "frame-decode 0.7.0",
+ "frame-metadata 20.0.0",
  "hashbrown 0.14.5",
  "hex",
  "impl-serde",
@@ -10345,16 +10334,16 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "subxt-metadata 0.40.0",
+ "subxt-metadata 0.41.0",
  "thiserror 2.0.12",
  "tracing",
 ]
 
 [[package]]
 name = "subxt-lightclient"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbf1a87957918fcfde2cc2150d792c752acb933f0f83262a8b42d96b8dfcc52"
+checksum = "ce07c2515b2e63b85ec3043fe4461b287af0615d4832c2fe6e81ba780b906bc0"
 dependencies = [
  "futures",
  "futures-util",
@@ -10369,9 +10358,9 @@ dependencies = [
 
 [[package]]
 name = "subxt-macro"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0a120bac6a4a07d477e736f42a388eebef47a277d2a76c8cddcf90e71ee4aa2"
+checksum = "7c2c8da275a620dd676381d72395dfea91f0a6cd849665b4f1d0919371850701"
 dependencies = [
  "darling",
  "parity-scale-codec",
@@ -10399,17 +10388,41 @@ dependencies = [
 
 [[package]]
 name = "subxt-metadata"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcee71f170e496294434c7c8646befc05e9a3a27a771712b4f3008d0c4d0ee7"
+checksum = "fff4591673600c4388e21305788282414d26c791b4dee21b7cb0b19c10076f98"
 dependencies = [
- "frame-decode 0.6.1",
- "frame-metadata 18.0.0",
+ "frame-decode 0.7.0",
+ "frame-metadata 20.0.0",
  "hashbrown 0.14.5",
  "parity-scale-codec",
  "scale-info",
  "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 2.0.12",
+]
+
+[[package]]
+name = "subxt-rpcs"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba7494d250d65dc3439365ac5e8e0fbb9c3992e6e84b7aa01d69e082249b8b8"
+dependencies = [
+ "derive-where",
+ "frame-metadata 20.0.0",
+ "futures",
+ "hex",
+ "impl-serde",
+ "jsonrpsee",
+ "parity-scale-codec",
+ "primitive-types 0.13.1",
+ "serde",
+ "serde_json",
+ "subxt-core 0.41.0",
+ "subxt-lightclient",
+ "thiserror 2.0.12",
+ "tokio-util",
+ "tracing",
+ "url",
 ]
 
 [[package]]
@@ -10443,9 +10456,9 @@ dependencies = [
 
 [[package]]
 name = "subxt-utils-fetchmetadata"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721556230144393c58ff3dd2660f734cc792fe19167823b957d6858b15e12362"
+checksum = "fc868b55fe2303788dc7703457af390111940c3da4714b510983284501780ed5"
 dependencies = [
  "hex",
  "parity-scale-codec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ pin-project-lite = "0.2"
 # subxt
 scale-value = "0.18"
 subxt = "0.41.0"
-subxt-core = "0.41.0"
 subxt-rpcs = "0.41.0"
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,16 +21,31 @@ serde = "1.0"
 serde_json = "1.0"
 futures = "0.3"
 thiserror = "2.0"
-tokio = { version = "1.44", features = ["macros", "rt-multi-thread", "sync", "signal"] }
+tokio = { version = "1.44", features = [
+    "macros",
+    "rt-multi-thread",
+    "sync",
+    "signal",
+] }
 pin-project-lite = "0.2"
 
 # subxt
 scale-value = "0.18"
-subxt = "0.40.0"
-subxt-core = "0.40.0"
+subxt = "0.41.0"
+subxt-core = "0.41.0"
+subxt-rpcs = "0.41.0"
+
 
 # polkadot-sdk
-polkadot-sdk = { git = "https://github.com/paritytech/polkadot-sdk", features = ["frame-election-provider-support", "frame-support", "sp-npos-elections", "sp-core", "sp-runtime", "pallet-election-provider-multi-phase", "pallet-election-provider-multi-block"], rev = "a92c3b2585" }
+polkadot-sdk = { git = "https://github.com/paritytech/polkadot-sdk", features = [
+    "frame-election-provider-support",
+    "frame-support",
+    "sp-npos-elections",
+    "sp-core",
+    "sp-runtime",
+    "pallet-election-provider-multi-phase",
+    "pallet-election-provider-multi-block",
+], rev = "a92c3b2585" }
 
 # prometheus
 prometheus = "0.14"

--- a/src/commands/legacy/dry_run.rs
+++ b/src/commands/legacy/dry_run.rs
@@ -102,7 +102,7 @@ where
             .create_signed(&tx, &*signer, params)
             .await?;
         let dry_run_bytes = client.rpc().dry_run(xt.encoded(), config.at).await?;
-        let dry_run_result = dry_run_bytes.into_dry_run_result(&client.chain_api().metadata())?;
+        let dry_run_result = dry_run_bytes.into_dry_run_result()?;
 
         log::info!(target: LOG_TARGET, "dry-run outcome is {:?}", dry_run_result);
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -58,15 +58,9 @@ pub enum Error {
     FailedToSubmitPages(usize),
 }
 
-impl From<subxt_core::Error> for Error {
-    fn from(e: subxt_core::Error) -> Self {
-        Self::Subxt(e.into())
-    }
-}
-
 impl From<subxt_rpcs::Error> for Error {
     fn from(e: subxt_rpcs::Error) -> Self {
-        Self::Other(format!("RPC error: {}", e))
+        Self::Subxt(subxt::Error::Rpc(e.into()))
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -63,3 +63,15 @@ impl From<subxt_core::Error> for Error {
         Self::Subxt(e.into())
     }
 }
+
+impl From<subxt_rpcs::Error> for Error {
+    fn from(e: subxt_rpcs::Error) -> Self {
+        Self::Other(format!("RPC error: {}", e))
+    }
+}
+
+impl From<subxt::backend::legacy::rpc_methods::DryRunDecodeError> for Error {
+    fn from(_e: subxt::backend::legacy::rpc_methods::DryRunDecodeError) -> Self {
+        Self::Other("Failed to decode dry run result".to_string())
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,15 +45,18 @@ mod static_types;
 mod utils;
 
 use clap::Parser;
-use dynamic::update_metadata_constants;
 use error::Error;
 use futures::future::{BoxFuture, FutureExt};
-use prelude::{ChainClient, DEFAULT_PROMETHEUS_PORT, DEFAULT_URI, LOG_TARGET, SHARED_CLIENT};
 use std::str::FromStr;
 use tokio::sync::oneshot;
 use tracing_subscriber::EnvFilter;
 
-use crate::{client::Client, opt::RuntimeVersion};
+use crate::{
+    client::Client,
+    dynamic::update_metadata_constants,
+    opt::RuntimeVersion,
+    prelude::{ChainClient, DEFAULT_PROMETHEUS_PORT, DEFAULT_URI, LOG_TARGET, SHARED_CLIENT},
+};
 
 #[derive(Debug, Clone, Parser)]
 #[cfg_attr(test, derive(PartialEq))]

--- a/src/signer.rs
+++ b/src/signer.rs
@@ -57,10 +57,6 @@ impl subxt::tx::Signer<Config> for PairSigner {
         self.account_id.clone()
     }
 
-    fn address(&self) -> <Config as subxt::Config>::Address {
-        self.account_id.clone().into()
-    }
-
     fn sign(&self, signer_payload: &[u8]) -> <Config as subxt::Config>::Signature {
         let signature = self.signer.sign(signer_payload);
         subxt::config::substrate::MultiSignature::Sr25519(signature.0)


### PR DESCRIPTION
Driven-by:
- remove subxt-core as dependency and add `subxt-rpcs` as dependency
- fix compilation errors coming from the version bump of `subxt`