### PR TITLE
[Experimental / DO NOT MERGE] Poll on-chain state instead of waiting for events

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is a re-write of the [staking miner](https://github.com/paritytech/polkadot
 The miner can work with two kinds of nodes:
 
 - **multi-phase (legacy)** , targeting the multi-phase, single paged election provider pallet
-- **multi-block (experimental) **, targeting the multi-phase, multi-block election provider pallet.
+- **multi-block (experimental)**, targeting the multi-phase, multi-block election provider pallet.
 
 The legacy path is intended to be temporary until all chains are migrated to multi-page staking (`asset-hub`).
 Once that occurs, we can remove the legacy components and rename the experimental monitor command to `monitor`.
@@ -102,6 +102,18 @@ This command is similar to the stable `monitor command` but targets the new pall
 
 ```bash
 polkadot-staking-miner --uri ws://127.0.0.1:9966 experimental-monitor-multi-block --seed-or-path //Alice
+```
+
+The `--chunk-size` option controls how many solution pages are submitted concurrently. When set to 0 (default), all pages are submitted at once. When set to a positive number, pages are submitted in chunks of that size, waiting for each chunk to be included in a block before submitting the next chunk. This can help manage network load and improve reliability on congested networks or if the pages per solution increases.
+
+```bash
+polkadot-staking-miner --uri ws://127.0.0.1:9966 experimental-monitor-multi-block --seed-or-path //Alice --chunk-size 4
+```
+
+The `--do-reduce` option (off by default) enables solution reduction, to prevent further trimming, making submission more efficient.
+
+```bash
+polkadot-staking-miner --uri ws://127.0.0.1:9966 experimental-monitor-multi-block --seed-or-path //Alice --do-reduce
 ```
 
 ### Prepare your SEED

--- a/src/commands/multi_block/monitor.rs
+++ b/src/commands/multi_block/monitor.rs
@@ -31,7 +31,7 @@ pub async fn monitor_cmd<T>(
 ) -> Result<(), Error>
 where
     T: MinerConfig<AccountId = AccountId> + Send + Sync + 'static,
-    T::Solution: Send,
+    T::Solution: Send + Sync + 'static,
     T::Pages: Send + Sync + 'static,
     T::TargetSnapshotPerBlock: Send + Sync + 'static,
     T::VoterSnapshotPerBlock: Send + Sync + 'static,
@@ -49,6 +49,7 @@ where
             .fetch(&runtime::storage().system().account(signer.account_id()))
             .await?
             .ok_or(Error::AccountDoesNotExists)?;
+
         prometheus::set_balance(account_info.data.free as f64);
 
         log::info!(
@@ -135,6 +136,7 @@ where
                 submit_lock,
                 config.submission_strategy,
                 config.do_reduce,
+                config.chunk_size,
             )
             .await
             {
@@ -165,14 +167,15 @@ async fn process_block<T>(
     submit_lock: Arc<Mutex<()>>,
     submission_strategy: SubmissionStrategy,
     do_reduce: bool,
+    chunk_size: usize,
 ) -> Result<(), Error>
 where
     T: MinerConfig<AccountId = AccountId> + Send + Sync + 'static,
-    T::Solution: Send,
-    T::Pages: Send,
+    T::Solution: Send + Sync + 'static,
+    T::Pages: Send + Sync + 'static,
     T::TargetSnapshotPerBlock: Send,
     T::VoterSnapshotPerBlock: Send,
-    T::MaxVotesPerVoter: Send,
+    T::MaxVotesPerVoter: Send + Sync + 'static,
 {
     let BlockDetails {
         storage,
@@ -268,7 +271,25 @@ where
                     missing_pages.push((page, solution));
                 }
 
-                dynamic::inner_submit_pages::<T>(&client, &signer, missing_pages, listen).await?;
+                // Use the appropriate submission method based on chunk_size
+                if chunk_size == 0 {
+                    dynamic::inner_submit_pages_concurrent::<T>(
+                        &client,
+                        &signer,
+                        missing_pages,
+                        listen,
+                    )
+                    .await?;
+                } else {
+                    dynamic::inner_submit_pages_chunked::<T>(
+                        &client,
+                        &signer,
+                        missing_pages,
+                        listen,
+                        chunk_size,
+                    )
+                    .await?;
+                }
                 return Ok(());
             }
 
@@ -301,7 +322,7 @@ where
     prometheus::set_score(paged_raw_solution.score);
 
     // 7. Submit the score and solution to the chain.
-    match dynamic::submit(&client, &signer, paged_raw_solution, listen)
+    match dynamic::submit(&client, &signer, paged_raw_solution, listen, chunk_size)
         .timed()
         .await
     {

--- a/src/commands/multi_block/monitor.rs
+++ b/src/commands/multi_block/monitor.rs
@@ -49,7 +49,6 @@ where
             .fetch(&runtime::storage().system().account(signer.account_id()))
             .await?
             .ok_or(Error::AccountDoesNotExists)?;
-
         prometheus::set_balance(account_info.data.free as f64);
 
         log::info!(

--- a/src/commands/types.rs
+++ b/src/commands/types.rs
@@ -185,4 +185,11 @@ pub struct ExperimentalMultiBlockMonitorConfig {
     /// Reduce the solution to prevent further trimming.
     #[clap(long, default_value_t = false)]
     pub do_reduce: bool,
+
+    /// Chunk size for submitting solution pages. If not specified or equal to zero,
+    /// all pages will be submitted concurrently. Otherwise, pages will be submitted in chunks
+    /// of the specified size, waiting for each chunk to be included in a block before
+    /// submitting the next chunk.
+    #[clap(long, default_value_t = 0)]
+    pub chunk_size: usize,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -397,6 +397,7 @@ mod tests {
                         listen: Listen::Finalized, // Assuming default
                         submission_strategy: SubmissionStrategy::IfLeading, // Assuming default
                         do_reduce: true,           // Expect true because flag was present
+                        chunk_size: 0,             // Default value
                     }
                 ),
             }
@@ -424,6 +425,35 @@ mod tests {
                     listen: Listen::Finalized,
                     submission_strategy: SubmissionStrategy::IfLeading,
                     do_reduce: false, // Expect false (default)
+                    chunk_size: 0,    // Default value
+                }
+            )
+        );
+    }
+
+    #[test]
+    fn cli_experimental_monitor_multi_block_with_chunk_size_works() {
+        let opt = Opt::try_parse_from([
+            env!("CARGO_PKG_NAME"),
+            "--uri",
+            "hi",
+            "experimental-monitor-multi-block",
+            "--seed-or-path",
+            "//Alice",
+            "--chunk-size",
+            "4",
+        ])
+        .unwrap();
+
+        assert_eq!(
+            opt.command,
+            Command::ExperimentalMonitorMultiBlock(
+                commands::types::ExperimentalMultiBlockMonitorConfig {
+                    seed_or_path: "//Alice".to_string(),
+                    listen: Listen::Finalized,
+                    submission_strategy: SubmissionStrategy::IfLeading,
+                    do_reduce: false, // Default value
+                    chunk_size: 4,    // Explicitly set to 4
                 }
             )
         );


### PR DESCRIPTION
This PR builds on top of [this change](https://github.com/paritytech/polkadot-staking-miner/pull/1016) introducing experimental support for chunked submission strategy.

This PR changes the page confirmation strategy in multi_block.rs to
match the approach used in monitor.rs as you can see from this [commit](https://github.com/paritytech/polkadot-staking-miner/pull/1020/commits/3615d356c2bef40eb34872c67f157cd27f5fd481).

1. Instead of waiting for specific events to confirm each page submission,
   we now poll the on-chain state with exponential backoff until we see
   the changes reflected in storage.

2. We track which pages have already been processed to avoid duplicate
   confirmations, ensuring each page is only logged once.

Testing via `zombienet` for both full concurrent and chunked strategies with 8 or 64 pages shows no advantage in terms of time compared to the current approach. The results are closely aligned, and the code does not appear any better to justify a change from the current method.

This PR is marked as experimental and is not meant to be merged in the current status.

Related issue: https://github.com/paritytech/polkadot-staking-miner/issues/987