### PR TITLE
Update hyper to v1.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3601,16 +3601,16 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.26"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
+checksum = "75249d144030531f8dee69fe9cea04d3edf809a017ae445e2abdff6629e86633"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "futures-util",
- "http 0.2.12",
+ "http",
  "indexmap 2.9.0",
  "slab",
  "tokio",
@@ -3766,17 +3766,6 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
@@ -3788,12 +3777,24 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 0.2.12",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -3817,26 +3818,37 @@ checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
 
 [[package]]
 name = "hyper"
-version = "0.14.32"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
 dependencies = [
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
  "h2",
- "http 0.2.12",
+ "http",
  "http-body",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "smallvec",
  "tokio",
- "tower-service",
- "tracing",
- "want",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -4230,7 +4242,7 @@ checksum = "bacb85abf4117092455e1573625e21b8f8ef4dec8aff13361140b2dc266cdff2"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
- "http 1.3.1",
+ "http",
  "jsonrpsee-core",
  "pin-project",
  "rustls",
@@ -4271,7 +4283,7 @@ version = "0.24.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08a8e70baf945b6b5752fc8eb38c918a48f1234daf11355e07106d963f860089"
 dependencies = [
- "http 1.3.1",
+ "http",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -4283,7 +4295,7 @@ version = "0.24.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01b3323d890aa384f12148e8d2a1fd18eb66e9e7e825f9de4fa53bcc19b93eef"
 dependencies = [
- "http 1.3.1",
+ "http",
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
  "jsonrpsee-types",
@@ -7440,7 +7452,9 @@ dependencies = [
  "assert_cmd",
  "clap",
  "futures",
+ "http-body-util",
  "hyper",
+ "hyper-util",
  "jsonrpsee",
  "log",
  "once_cell",
@@ -10786,12 +10800,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tower-service"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
-
-[[package]]
 name = "tracing"
 version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10874,12 +10882,6 @@ checksum = "d4ed310ef5ab98f5fa467900ed906cb9232dd5376597e00fd4cba2a449d06c0b"
 dependencies = [
  "hash-db",
 ]
-
-[[package]]
-name = "try-lock"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tt-call"
@@ -11110,15 +11112,6 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
-]
-
-[[package]]
-name = "want"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
-dependencies = [
- "try-lock",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,13 @@ polkadot-sdk = { git = "https://github.com/paritytech/polkadot-sdk", features = 
 
 # prometheus
 prometheus = "0.14"
-hyper = { version = "0.14.32", features = ["server", "http1", "http2", "tcp"] }
+hyper = { version = "1.6.0", features = ["server", "http1", "http2"] }
+hyper-util = { version = "0.1.11", features = [
+    "server-auto",
+    "server-graceful",
+    "tokio",
+] }
+http-body-util = "0.1.0"
 once_cell = "1.21"
 
 [dev-dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -111,9 +111,9 @@ async fn main() -> Result<(), Error> {
     let runtime_version: RuntimeVersion =
         client.rpc().state_get_runtime_version(None).await?.into();
     let chain = opt::Chain::from_str(&runtime_version.spec_name)?;
-    let _prometheus_handle = prometheus::run(prometheus_port)
-        .await
-        .map_err(|e| log::warn!("Failed to start prometheus endpoint: {}", e));
+    if let Err(e) = prometheus::run(prometheus_port).await {
+        log::warn!("Failed to start prometheus endpoint: {}", e);
+    }
     log::info!(target: LOG_TARGET, "Connected to chain: {}", chain);
 
     let is_legacy = !matches!(command, Command::ExperimentalMonitorMultiBlock(_));

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,6 +112,7 @@ async fn main() -> Result<(), Error> {
         client.rpc().state_get_runtime_version(None).await?.into();
     let chain = opt::Chain::from_str(&runtime_version.spec_name)?;
     let _prometheus_handle = prometheus::run(prometheus_port)
+        .await
         .map_err(|e| log::warn!("Failed to start prometheus endpoint: {}", e));
     log::info!(target: LOG_TARGET, "Connected to chain: {}", chain);
 


### PR DESCRIPTION
This commit updates the hyper dependency to version 1.6.0.

Changes:

- Updated hyper dependency in Cargo.toml

- Updated Cargo.lock with new hyper version

- Modified prometheus.rs to use the new hyper API

The changes closely match the implementation in the SDK substrate util prometheus library.

Fixes #1011