### PR TITLE
Fix invalid build-polkadot-for-nightly.yml

### DIFF
--- a/.github/workflows/actions/prepare-binaries/action.yml
+++ b/.github/workflows/actions/prepare-binaries/action.yml
@@ -24,8 +24,8 @@ runs:
         ./tmp/polkadot --version
         ./tmp/staking-miner-playground --version
         mkdir -p /usr/local/bin
-        mkdir -p /etc/polkadot-staking-miner
+        sudo mkdir -p /etc/polkadot-staking-miner
         mv ./tmp/polkadot* /usr/local/bin
         mv ./tmp/staking-miner-playground /usr/local/bin
-        mv ./tmp/parachain.json /etc/polkadot-staking-miner
-        mv ./tmp/rc.json /etc/polkadot-staking-miner
+        sudo mv ./tmp/parachain.json /etc/polkadot-staking-miner
+        sudo mv ./tmp/rc.json /etc/polkadot-staking-miner

--- a/.github/workflows/build-polkadot-for-nightly.yml
+++ b/.github/workflows/build-polkadot-for-nightly.yml
@@ -60,10 +60,10 @@ jobs:
 
       - name: Verify built binaries
         run: |
-        ./target/release/polkadot --version
-        ./target/release/polkadot-parachain --version
-        ./target/release/polkadot-prepare-worker --version
-        ./target/release/polkadot-execute-worker --version
+          ./target/release/polkadot --version
+          ./target/release/polkadot-parachain --version
+          ./target/release/polkadot-prepare-worker --version
+          ./target/release/polkadot-execute-worker --version
 
       - name: upload polkadot artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Commit 867fc62 (#1040) has introduced a YAML file for building polkadot for nightly with an invalid syntax, preventing the multi-block integration test to run properly.

Close #1048 , creating /etc/polkadot-staking-miner via `sudo`.