### PR TITLE
Switch jobs to parity-large

### DIFF
--- a/.github/workflows/build-polkadot-for-nightly.yml
+++ b/.github/workflows/build-polkadot-for-nightly.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   tests:
     name: Build polkadot binary
-    runs-on: ubuntu-latest
+    runs-on: parity-large
     container: docker.io/paritytech/ci-unified:bullseye-1.85.0-2025-01-28-v202504231537
     steps:
       - name: checkout polkadot-sdk

--- a/.github/workflows/build-staking-miner-playground-for-nightly.yml
+++ b/.github/workflows/build-staking-miner-playground-for-nightly.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   tests:
     name: Build staking-miner-playground
-    runs-on: ubuntu-latest
+    runs-on: parity-large
     container: docker.io/paritytech/ci-unified:bullseye-1.85.0-2025-01-28-v202504231537
     steps:
       - name: checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
   set-image:
     # GitHub Actions does not allow using 'env' in a container context.
     # This workaround sets the container image for each job using 'set-image' job output.
-    runs-on: ubuntu-latest
+    runs-on: parity-large
     outputs:
       IMAGE: ${{ steps.set_image.outputs.IMAGE }}
     steps:
@@ -32,7 +32,7 @@ jobs:
 
   check-fmt:
     name: Check formatting
-    runs-on: ubuntu-latest
+    runs-on: parity-large
     needs: [set-image]
     container: ${{ needs.set-image.outputs.IMAGE }}
     steps:
@@ -46,7 +46,7 @@ jobs:
 
   check-clippy:
     name: Clippy
-    runs-on: ubuntu-latest
+    runs-on: parity-large
     needs: [set-image]
     container: ${{ needs.set-image.outputs.IMAGE }}
     steps:
@@ -65,7 +65,7 @@ jobs:
 
   check-docs:
     name: Check documentation
-    runs-on: ubuntu-latest
+    runs-on: parity-large
     needs: [set-image]
     container: ${{ needs.set-image.outputs.IMAGE }}
     steps:
@@ -84,7 +84,7 @@ jobs:
 
   check-code:
     name: Check code
-    runs-on: ubuntu-latest
+    runs-on: parity-large
     needs: [set-image]
     container: ${{ needs.set-image.outputs.IMAGE }}
 
@@ -104,7 +104,7 @@ jobs:
 
   test:
     name: Run tests
-    runs-on: ubuntu-latest
+    runs-on: parity-large
     needs: [set-image]
     container: ${{ needs.set-image.outputs.IMAGE }}
     steps:
@@ -126,7 +126,7 @@ jobs:
 
   build:
     name: Build polkadot-staking-miner binary
-    runs-on: ubuntu-latest
+    runs-on: parity-large
     needs: [set-image]
     container: ${{ needs.set-image.outputs.IMAGE }}
     steps:
@@ -157,7 +157,7 @@ jobs:
   build-docker-image:
     name: Test Docker image build
     if: ${{ github.event_name == 'pull_request' }}
-    runs-on: ubuntu-latest
+    runs-on: parity-large
     needs: [check-fmt, check-clippy, check-docs, check-code, test, build]
     steps:
       - name: Checkout repository
@@ -190,7 +190,7 @@ jobs:
   publish-docker-image:
     name: Build and publish Docker image
     if: ${{ github.ref == 'refs/heads/main' ||  github.ref_type == 'tag' }}
-    runs-on: ubuntu-latest
+    runs-on: parity-large
     environment: main_and_tags
     needs: [check-fmt, check-clippy, check-docs, check-code, test, build]
     steps:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,17 +2,17 @@ name: Nightly test
 
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: "0 0 * * *"
   workflow_dispatch:
 
 jobs:
   nightly-test:
-    runs-on: ubuntu-latest
+    runs-on: parity-large
     strategy:
       matrix:
         channel:
-          - name: 'Staking Miner Dev'
-            room: '!tXyUlsDAYvDfRKbzKx:parity.io'
+          - name: "Staking Miner Dev"
+            room: "!tXyUlsDAYvDfRKbzKx:parity.io"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: "18"
 
       - name: Install zombienet globally
         run: npm install -g @zombienet/cli
@@ -66,4 +66,3 @@ jobs:
           server: m.parity.io
           message: |
             @room Daily integration tests failed https://github.com/${{ github.repository }}/commit/${{ github.sha }}/checks/${{ github.run_id }}
-

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,7 +2,7 @@ name: Nightly test
 
 on:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: '0 0 * * *'
   workflow_dispatch:
 
 jobs:
@@ -11,8 +11,8 @@ jobs:
     strategy:
       matrix:
         channel:
-          - name: "Staking Miner Dev"
-            room: "!tXyUlsDAYvDfRKbzKx:parity.io"
+          - name: 'Staking Miner Dev'
+            room: '!tXyUlsDAYvDfRKbzKx:parity.io'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: '18'
 
       - name: Install zombienet globally
         run: npm install -g @zombienet/cli

--- a/.github/workflows/publish-docker-description.yml
+++ b/.github/workflows/publish-docker-description.yml
@@ -3,13 +3,13 @@ name: Publish Docker image description
 on:
   push:
     branches:
-      - 'main'
+      - "main"
     paths:
-      - 'Dockerfile.README.md'
+      - "Dockerfile.README.md"
 
 jobs:
   publish_docker_description:
-    runs-on: ubuntu-latest
+    runs-on: parity-large
     environment: main_and_tags
     steps:
       - name: Checkout
@@ -20,6 +20,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          repository: 'paritytech/polkadot-staking-miner'
-          short-description: 'polkadot-staking-miner'
-          readme-filepath: 'Dockerfile.README.md'
+          repository: "paritytech/polkadot-staking-miner"
+          short-description: "polkadot-staking-miner"
+          readme-filepath: "Dockerfile.README.md"

--- a/.github/workflows/publish-docker-description.yml
+++ b/.github/workflows/publish-docker-description.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - 'main'
     paths:
-      - "Dockerfile.README.md"
+      - 'Dockerfile.README.md'
 
 jobs:
   publish_docker_description:

--- a/.github/workflows/publish-docker-description.yml
+++ b/.github/workflows/publish-docker-description.yml
@@ -3,7 +3,7 @@ name: Publish Docker image description
 on:
   push:
     branches:
-      - "main"
+      - 'main'
     paths:
       - "Dockerfile.README.md"
 
@@ -20,6 +20,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          repository: "paritytech/polkadot-staking-miner"
-          short-description: "polkadot-staking-miner"
-          readme-filepath: "Dockerfile.README.md"
+          repository: 'paritytech/polkadot-staking-miner'
+          short-description: 'polkadot-staking-miner'
+          readme-filepath: 'Dockerfile.README.md'

--- a/.github/workflows/staking-miner-playground.yml
+++ b/.github/workflows/staking-miner-playground.yml
@@ -20,7 +20,7 @@ jobs:
   set-image:
     # GitHub Actions does not allow using 'env' in a container context.
     # This workaround sets the container image for each job using 'set-image' job output.
-    runs-on: ubuntu-latest
+    runs-on: parity-large
     outputs:
       IMAGE: ${{ steps.set_image.outputs.IMAGE }}
     steps:
@@ -29,7 +29,7 @@ jobs:
 
   check:
     name: Check staking-miner-playground
-    runs-on: ubuntu-latest
+    runs-on: parity-large
     needs: [set-image]
     container: ${{ needs.set-image.outputs.IMAGE }}
     steps:


### PR DESCRIPTION
This should fix the issue we were having with the public available runner with just 14GB of disk space, resulting in jobs failing due to no space left.