### PR TITLE
CI: fix path of polkadot binaries in action.yml

### DIFF
--- a/.github/workflows/actions/prepare-binaries/action.yml
+++ b/.github/workflows/actions/prepare-binaries/action.yml
@@ -20,12 +20,12 @@ runs:
     - name: Setup permissions and move to path
       shell: bash
       run: |
-        chmod u+x ./tmp/polkadot* ./tmp/staking-miner-playground
-        ./tmp/polkadot --version
+        chmod u+x ./tmp/target/release/polkadot* ./tmp/staking-miner-playground
+        ./tmp/target/release/polkadot --version
         ./tmp/staking-miner-playground --version
         mkdir -p /usr/local/bin
         mkdir -p ${HOME}/.config/polkadot-staking-miner
-        mv ./tmp/polkadot* /usr/local/bin
+        mv ./tmp/target/release/polkadot* /usr/local/bin
         mv ./tmp/staking-miner-playground /usr/local/bin
         mv ./tmp/parachain.json ${HOME}/.config/polkadot-staking-miner
         mv ./tmp/rc.json ${HOME}/.config/polkadot-staking-miner

--- a/.github/workflows/actions/prepare-binaries/action.yml
+++ b/.github/workflows/actions/prepare-binaries/action.yml
@@ -23,9 +23,10 @@ runs:
         chmod u+x ./tmp/target/release/polkadot* ./tmp/staking-miner-playground
         ./tmp/target/release/polkadot --version
         ./tmp/staking-miner-playground --version
-        mkdir -p /usr/local/bin
+        mkdir -p ${HOME}/.local/bin
+        echo "${HOME}/.local/bin" >> $GITHUB_PATH
         mkdir -p ${HOME}/.config/polkadot-staking-miner
-        mv ./tmp/target/release/polkadot* /usr/local/bin
-        mv ./tmp/staking-miner-playground /usr/local/bin
+        mv ./tmp/target/release/polkadot* ${HOME}/.local/bin
+        mv ./tmp/staking-miner-playground ${HOME}/.local/bin
         mv ./tmp/parachain.json ${HOME}/.config/polkadot-staking-miner
         mv ./tmp/rc.json ${HOME}/.config/polkadot-staking-miner

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,6 +5,10 @@ on:
     - cron: "0 0 * * *"
   workflow_dispatch:
 
+env:
+  IMAGE: docker.io/paritytech/ci-unified:bullseye-1.85.0-2025-01-28-v202504231537
+  RUST_INFO: rustup show && cargo --version && rustup +nightly show && cargo +nightly --version
+
 jobs:
   nightly-test:
     runs-on: parity-large

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: '18'
 
       - name: Install zombienet globally
         run: npm install -g @zombienet/cli
@@ -73,12 +73,12 @@ jobs:
           # create a new one if we only find closed versions):
           search_existing: open
 
-      # - name: Notify daily integration tests failure
-      #   if: failure()
-      #   uses: s3krit/matrix-message-action@70ad3fb812ee0e45ff8999d6af11cafad11a6ecf # v0.0.3
-      #   with:
-      #     room_id: ${{ matrix.channel.room }}
-      #     access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
-      #     server: m.parity.io
-      #     message: |
-      #       @room Daily integration tests failed https://github.com/${{ github.repository }}/commit/${{ github.sha }}/checks/${{ github.run_id }}
+      - name: Notify daily integration tests failure
+        if: failure()
+        uses: s3krit/matrix-message-action@70ad3fb812ee0e45ff8999d6af11cafad11a6ecf # v0.0.3
+        with:
+          room_id: ${{ matrix.channel.room }}
+          access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
+          server: m.parity.io
+          message: |
+            @room Daily integration tests failed https://github.com/${{ github.repository }}/commit/${{ github.sha }}/checks/${{ github.run_id }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -73,12 +73,12 @@ jobs:
           # create a new one if we only find closed versions):
           search_existing: open
 
-      - name: Notify daily integration tests failure
-        if: failure()
-        uses: s3krit/matrix-message-action@70ad3fb812ee0e45ff8999d6af11cafad11a6ecf # v0.0.3
-        with:
-          room_id: ${{ matrix.channel.room }}
-          access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
-          server: m.parity.io
-          message: |
-            @room Daily integration tests failed https://github.com/${{ github.repository }}/commit/${{ github.sha }}/checks/${{ github.run_id }}
+      # - name: Notify daily integration tests failure
+      #   if: failure()
+      #   uses: s3krit/matrix-message-action@70ad3fb812ee0e45ff8999d6af11cafad11a6ecf # v0.0.3
+      #   with:
+      #     room_id: ${{ matrix.channel.room }}
+      #     access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
+      #     server: m.parity.io
+      #     message: |
+      #       @room Daily integration tests failed https://github.com/${{ github.repository }}/commit/${{ github.sha }}/checks/${{ github.run_id }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,7 +2,7 @@ name: Nightly test
 
 on:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: '0 0 * * *'
   workflow_dispatch:
 
 env:
@@ -10,13 +10,25 @@ env:
   RUST_INFO: rustup show && cargo --version && rustup +nightly show && cargo +nightly --version
 
 jobs:
+  set-image:
+    # GitHub Actions does not allow using 'env' in a container context.
+    # This workaround sets the container image for each job using 'set-image' job output.
+    runs-on: parity-large
+    outputs:
+      IMAGE: ${{ steps.set_image.outputs.IMAGE }}
+    steps:
+      - id: set_image
+        run: echo "IMAGE=${{ env.IMAGE }}" >> $GITHUB_OUTPUT
+
   nightly-test:
     runs-on: parity-large
+    needs: [set-image]
+    container: ${{ needs.set-image.outputs.IMAGE }}
     strategy:
       matrix:
         channel:
-          - name: "Staking Miner Dev"
-            room: "!tXyUlsDAYvDfRKbzKx:parity.io"
+          - name: 'Staking Miner Dev'
+            room: '!tXyUlsDAYvDfRKbzKx:parity.io'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,7 +2,7 @@ name: Nightly test
 
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: "0 0 * * *"
   workflow_dispatch:
 
 jobs:
@@ -11,8 +11,8 @@ jobs:
     strategy:
       matrix:
         channel:
-          - name: 'Staking Miner Dev'
-            room: '!tXyUlsDAYvDfRKbzKx:parity.io'
+          - name: "Staking Miner Dev"
+            room: "!tXyUlsDAYvDfRKbzKx:parity.io"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -23,13 +23,13 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: "18"
 
       - name: Install zombienet globally
         run: npm install -g @zombienet/cli
 
       - name: Verify zombienet installation
-        run: zombienet --version
+        run: zombienet --help
 
       - name: Cache Rust dependencies
         uses: swatinem/rust-cache@v2

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -73,12 +73,12 @@ jobs:
           # create a new one if we only find closed versions):
           search_existing: open
 
-      # - name: Notify daily integration tests failure
-      #   if: failure()
-      #   uses: s3krit/matrix-message-action@70ad3fb812ee0e45ff8999d6af11cafad11a6ecf # v0.0.3
-      #   with:
-      #     room_id: ${{ matrix.channel.room }}
-      #     access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
-      #     server: m.parity.io
-      #     message: |
-      #       @room Daily integration tests failed https://github.com/${{ github.repository }}/commit/${{ github.sha }}/checks/${{ github.run_id }}
+      - name: Notify daily integration tests failure
+        if: failure()
+        uses: s3krit/matrix-message-action@70ad3fb812ee0e45ff8999d6af11cafad11a6ecf # v0.0.3
+        with:
+          room_id: ${{ matrix.channel.room }}
+          access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
+          server: m.parity.io
+          message: |
+            @room Daily integration tests failed https://github.com/${{ github.repository }}/commit/${{ github.sha }}/checks/${{ github.run_id }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -57,12 +57,12 @@ jobs:
           # create a new one if we only find closed versions):
           search_existing: open
 
-      - name: Notify daily integration tests failure
-        if: failure()
-        uses: s3krit/matrix-message-action@70ad3fb812ee0e45ff8999d6af11cafad11a6ecf # v0.0.3
-        with:
-          room_id: ${{ matrix.channel.room }}
-          access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
-          server: m.parity.io
-          message: |
-            @room Daily integration tests failed https://github.com/${{ github.repository }}/commit/${{ github.sha }}/checks/${{ github.run_id }}
+      # - name: Notify daily integration tests failure
+      #   if: failure()
+      #   uses: s3krit/matrix-message-action@70ad3fb812ee0e45ff8999d6af11cafad11a6ecf # v0.0.3
+      #   with:
+      #     room_id: ${{ matrix.channel.room }}
+      #     access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
+      #     server: m.parity.io
+      #     message: |
+      #       @room Daily integration tests failed https://github.com/${{ github.repository }}/commit/${{ github.sha }}/checks/${{ github.run_id }}

--- a/tests/multi_block_monitor.rs
+++ b/tests/multi_block_monitor.rs
@@ -48,7 +48,7 @@ fn run_miner(port: u16) -> KillChildOnDrop {
                 "--seed-or-path",
                 "//Alice",
             ])
-            .env("RUST_LOG", "trace,polkadot_staking_miner=trace")
+            .env("RUST_LOG", "debug,polkadot_staking_miner=info")
             .spawn()
             .unwrap(),
     );
@@ -190,7 +190,7 @@ async fn run_zombienet() -> (KillChildOnDrop, u16) {
             .stdout(process::Stdio::piped())
             .stderr(process::Stdio::piped())
             .args(["--provider", "native", "-l", "text", "spawn", config_path])
-            .env("RUST_LOG", "info,runtime=debug")
+            .env("RUST_LOG", "error,runtime=error")
             .spawn()
             .unwrap(),
     );

--- a/zombienet-staking-runtimes.toml
+++ b/zombienet-staking-runtimes.toml
@@ -1,6 +1,6 @@
 [relaychain]
 default_command = "polkadot"
-chain_spec_path = "${HOME}/.config/polkadot-staking-miner/rc.json"
+chain_spec_path = "/github/home/.config/polkadot-staking-miner/rc.json"
 
 [[relaychain.nodes]]
 name = "alice"
@@ -17,7 +17,7 @@ args = [
 
 [[parachains]]
 id = 1100
-chain_spec_path = "${HOME}/.config/polkadot-staking-miner/parachain.json"
+chain_spec_path = "/github/home/.config/polkadot-staking-miner/parachain.json"
 
 [parachains.collator]
 name = "charlie"


### PR DESCRIPTION
We are uploading polkadot binaries under `target/release` in `build-polkadot-for-nightly.yml` . We should access them under `target/release`  in `action.yml` to avoid CI to file like [here](https://github.com/paritytech/polkadot-staking-miner/actions/runs/15040937569/job/42272279818).

Close #1051 