### PR TITLE
CI/CD: more verbose logs for EPMB and staking

### DIFF
--- a/.github/workflows/build-polkadot-for-nightly.yml
+++ b/.github/workflows/build-polkadot-for-nightly.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   tests:
     name: Build polkadot binary
-    runs-on: parity-large
+    runs-on: ubuntu-latest
     container: docker.io/paritytech/ci-unified:bullseye-1.85.0-2025-01-28-v202504231537
     steps:
       - name: checkout polkadot-sdk

--- a/.github/workflows/build-staking-miner-playground-for-nightly.yml
+++ b/.github/workflows/build-staking-miner-playground-for-nightly.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   tests:
     name: Build staking-miner-playground
-    runs-on: parity-large
+    runs-on: ubuntu-latest
     container: docker.io/paritytech/ci-unified:bullseye-1.85.0-2025-01-28-v202504231537
     steps:
       - name: checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
   set-image:
     # GitHub Actions does not allow using 'env' in a container context.
     # This workaround sets the container image for each job using 'set-image' job output.
-    runs-on: parity-large
+    runs-on: ubuntu-latest
     outputs:
       IMAGE: ${{ steps.set_image.outputs.IMAGE }}
     steps:
@@ -32,7 +32,7 @@ jobs:
 
   check-fmt:
     name: Check formatting
-    runs-on: parity-large
+    runs-on: ubuntu-latest
     needs: [set-image]
     container: ${{ needs.set-image.outputs.IMAGE }}
     steps:
@@ -46,7 +46,7 @@ jobs:
 
   check-clippy:
     name: Clippy
-    runs-on: parity-large
+    runs-on: ubuntu-latest
     needs: [set-image]
     container: ${{ needs.set-image.outputs.IMAGE }}
     steps:
@@ -65,7 +65,7 @@ jobs:
 
   check-docs:
     name: Check documentation
-    runs-on: parity-large
+    runs-on: ubuntu-latest
     needs: [set-image]
     container: ${{ needs.set-image.outputs.IMAGE }}
     steps:
@@ -84,7 +84,7 @@ jobs:
 
   check-code:
     name: Check code
-    runs-on: parity-large
+    runs-on: ubuntu-latest
     needs: [set-image]
     container: ${{ needs.set-image.outputs.IMAGE }}
 
@@ -104,7 +104,7 @@ jobs:
 
   test:
     name: Run tests
-    runs-on: parity-large
+    runs-on: ubuntu-latest
     needs: [set-image]
     container: ${{ needs.set-image.outputs.IMAGE }}
     steps:
@@ -126,7 +126,7 @@ jobs:
 
   build:
     name: Build polkadot-staking-miner binary
-    runs-on: parity-large
+    runs-on: ubuntu-latest
     needs: [set-image]
     container: ${{ needs.set-image.outputs.IMAGE }}
     steps:
@@ -157,7 +157,7 @@ jobs:
   build-docker-image:
     name: Test Docker image build
     if: ${{ github.event_name == 'pull_request' }}
-    runs-on: parity-large
+    runs-on: ubuntu-latest
     needs: [check-fmt, check-clippy, check-docs, check-code, test, build]
     steps:
       - name: Checkout repository
@@ -190,7 +190,7 @@ jobs:
   publish-docker-image:
     name: Build and publish Docker image
     if: ${{ github.ref == 'refs/heads/main' ||  github.ref_type == 'tag' }}
-    runs-on: parity-large
+    runs-on: ubuntu-latest
     environment: main_and_tags
     needs: [check-fmt, check-clippy, check-docs, check-code, test, build]
     steps:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,7 +13,7 @@ jobs:
   set-image:
     # GitHub Actions does not allow using 'env' in a container context.
     # This workaround sets the container image for each job using 'set-image' job output.
-    runs-on: parity-large
+    runs-on: ubuntu-latest
     outputs:
       IMAGE: ${{ steps.set_image.outputs.IMAGE }}
     steps:
@@ -21,7 +21,7 @@ jobs:
         run: echo "IMAGE=${{ env.IMAGE }}" >> $GITHUB_OUTPUT
 
   nightly-test:
-    runs-on: parity-large
+    runs-on: ubuntu-latest
     needs: [set-image]
     container: ${{ needs.set-image.outputs.IMAGE }}
     strategy:

--- a/.github/workflows/publish-docker-description.yml
+++ b/.github/workflows/publish-docker-description.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   publish_docker_description:
-    runs-on: parity-large
+    runs-on: ubuntu-latest
     environment: main_and_tags
     steps:
       - name: Checkout

--- a/.github/workflows/staking-miner-playground.yml
+++ b/.github/workflows/staking-miner-playground.yml
@@ -20,7 +20,7 @@ jobs:
   set-image:
     # GitHub Actions does not allow using 'env' in a container context.
     # This workaround sets the container image for each job using 'set-image' job output.
-    runs-on: parity-large
+    runs-on: ubuntu-latest
     outputs:
       IMAGE: ${{ steps.set_image.outputs.IMAGE }}
     steps:
@@ -29,7 +29,7 @@ jobs:
 
   check:
     name: Check staking-miner-playground
-    runs-on: parity-large
+    runs-on: ubuntu-latest
     needs: [set-image]
     container: ${{ needs.set-image.outputs.IMAGE }}
     steps:

--- a/tests/multi_block_monitor.rs
+++ b/tests/multi_block_monitor.rs
@@ -48,7 +48,7 @@ fn run_miner(port: u16) -> KillChildOnDrop {
                 "--seed-or-path",
                 "//Alice",
             ])
-            .env("RUST_LOG", "debug,polkadot_staking_miner=info")
+            .env("RUST_LOG", "debug,polkadot_staking_miner=trace")
             .spawn()
             .unwrap(),
     );

--- a/zombienet-staking-runtimes.toml
+++ b/zombienet-staking-runtimes.toml
@@ -23,5 +23,5 @@ chain_spec_path = "/github/home/.config/polkadot-staking-miner/parachain.json"
 name = "charlie"
 rpc_port = 9966
 args = [
-	"-lruntime::system=debug,runtime::multiblock-election=debug,runtime::staking=debug,runtime::staking::rc-client=trace",
+	"-lruntime::system=debug,runtime::multiblock-election=trace,runtime::staking=info,runtime::staking::rc-client=trace",
 ]

--- a/zombienet-staking-runtimes.toml
+++ b/zombienet-staking-runtimes.toml
@@ -23,5 +23,5 @@ chain_spec_path = "/github/home/.config/polkadot-staking-miner/parachain.json"
 name = "charlie"
 rpc_port = 9966
 args = [
-	"-lruntime::system=debug,runtime::multiblock-election=trace,runtime::staking=info,runtime::staking::rc-client=trace",
+	"-lruntime::system=debug,runtime::multiblock-election=trace,runtime::staking=debug,runtime::staking::rc-client=trace",
 ]


### PR DESCRIPTION
We have seen the multi-block integration test failing once so far in CI/CD (see #1055). If it happens again, let's make sure to have enough info on EPMB/staking side.
Let's also make the miner itself more verbose.

NOTE: in order to be able to build the docker image via CI, we also revert #1052  and use again `ubuntu-latest` as runner, hoping not to hit again the `no disk space left` issue.