### PR TITLE
Use parity-large only for more resourceful jobs

### DIFF
--- a/.github/workflows/build-polkadot-for-nightly.yml
+++ b/.github/workflows/build-polkadot-for-nightly.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   tests:
     name: Build polkadot binary
-    runs-on: ubuntu-latest
+    runs-on: parity-large
     container: docker.io/paritytech/ci-unified:bullseye-1.85.0-2025-01-28-v202504231537
     steps:
       - name: checkout polkadot-sdk

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
 
   test:
     name: Run tests
-    runs-on: ubuntu-latest
+    runs-on: parity-large
     needs: [set-image]
     container: ${{ needs.set-image.outputs.IMAGE }}
     steps:
@@ -126,7 +126,7 @@ jobs:
 
   build:
     name: Build polkadot-staking-miner binary
-    runs-on: ubuntu-latest
+    runs-on: parity-large
     needs: [set-image]
     container: ${{ needs.set-image.outputs.IMAGE }}
     steps:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,7 +13,7 @@ jobs:
   set-image:
     # GitHub Actions does not allow using 'env' in a container context.
     # This workaround sets the container image for each job using 'set-image' job output.
-    runs-on: ubuntu-latest
+    runs-on: parity-large
     outputs:
       IMAGE: ${{ steps.set_image.outputs.IMAGE }}
     steps:
@@ -21,7 +21,7 @@ jobs:
         run: echo "IMAGE=${{ env.IMAGE }}" >> $GITHUB_OUTPUT
 
   nightly-test:
-    runs-on: ubuntu-latest
+    runs-on: parity-large
     needs: [set-image]
     container: ${{ needs.set-image.outputs.IMAGE }}
     strategy:


### PR DESCRIPTION
We are facing two different issues when it comes to CI:
1. no disk space left for jobs running on `ubuntu-latest` runner
2. when we tried building docker image on `parity-large`, we got an error while attempting to mount `/sys` (which isn't done by our workflow or Dockerfile directly though)

Let's try to reserve `parity-large` for more resourceful jobs only, like the ones building artifacts and use `ubuntu-latest` for things like checking format and building the docker image.