### PR TITLE
Add min signed phase blocks validation

### DIFF
--- a/.github/workflows/actions/prepare-binaries/README.md
+++ b/.github/workflows/actions/prepare-binaries/README.md
@@ -1,4 +1,3 @@
-# Prepare polkadot and staking-miner-playground binaries
+# Prepare polkadot binaries
 
-This action downloads the Polkadot and Staking miner binaries produced from workflows
-`build-polkadot-for-nightly.yml` and `build-staking-miner-playground-for-nightly.yml` and puts them into the `$PATH`.
+This action downloads the Polkadot binaries produced from workflows `build-polkadot-for-nightly.yml` and puts them into the `$PATH`.

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,7 +2,7 @@ name: Nightly test
 
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: "0 0 * * *"
   workflow_dispatch:
 
 env:
@@ -27,19 +27,19 @@ jobs:
     strategy:
       matrix:
         channel:
-          - name: 'Staking Miner Dev'
-            room: '!tXyUlsDAYvDfRKbzKx:parity.io'
+          - name: "Staking Miner Dev"
+            room: "!tXyUlsDAYvDfRKbzKx:parity.io"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Get Polkadot and Staking Miner Playground binaries
+      - name: Get Polkadot binaries
         uses: ./.github/workflows/actions/prepare-binaries
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: "18"
 
       - name: Install zombienet globally
         run: npm install -g @zombienet/cli

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Here are some notable options you can use with the command:
 | `--do-reduce`                        | Enables solution reduction to make submissions more efficient.                      | Off             |
 | `--listen <finalized\|head>`         | Determines the listening mode.                                                      | finalized       |
 | `--submission-strategy <strategy>`   | Sets the submission strategy.                                                       | `if-leading`    |
-| `--min_signed_phase_blocks <number>` | Minimum number of blocks required in the signed phase before submitting a solution. | 10              |
+| `--min-signed-phase-blocks <number>` | Minimum number of blocks required in the signed phase before submitting a solution. | 10              |
 
 Refer to `--help` for the full list of options.
 

--- a/README.md
+++ b/README.md
@@ -68,22 +68,15 @@ To mine a solution and earn rewards, use a command like the following:
 polkadot-staking-miner --uri ws://127.0.0.1:9946 monitor --seed-or-path //Alice
 ```
 
-The `--chunk-size` option controls how many solution pages are submitted concurrently. When set to 0 (default), all pages are submitted at once. When set to a positive number, pages are submitted in chunks of that size, waiting for each chunk to be included in a block before submitting the next chunk. This can help manage network load and improve reliability on congested networks or if the pages per solution increases.
+Here are some notable options you can use with the command:
 
-```bash
-polkadot-staking-miner --uri ws://127.0.0.1:9946 monitor --seed-or-path //Alice --chunk-size 4
-```
-
-The `--do-reduce` option (off by default) enables solution reduction, to prevent further trimming, making submission more efficient.
-
-```bash
-polkadot-staking-miner --uri ws://127.0.0.1:9966 monitor --seed-or-path //Alice --do-reduce
-```
-
-Other notable options are:
-
-- `--listen` (default: finalized, possible values: finalized or head)
-- `--submission-strategy` (default: `if-leading`)
+| Option                               | Description                                                                         | Default Value   |
+| :----------------------------------- | :---------------------------------------------------------------------------------- | :-------------- |
+| `--chunk-size <number>`              | Controls how many solution pages are submitted concurrently.                        | 0 (all at once) |
+| `--do-reduce`                        | Enables solution reduction to make submissions more efficient.                      | Off             |
+| `--listen <finalized\|head>`         | Determines the listening mode.                                                      | finalized       |
+| `--submission-strategy <strategy>`   | Sets the submission strategy.                                                       | `if-leading`    |
+| `--min_signed_phase_blocks <number>` | Minimum number of blocks required in the signed phase before submitting a solution. | 10              |
 
 Refer to `--help` for the full list of options.
 

--- a/src/commands/multi_block/monitor.rs
+++ b/src/commands/multi_block/monitor.rs
@@ -449,10 +449,6 @@ where
 			}
 			log::trace!(target: LOG_TARGET, "Signed phase with {} blocks remaining - checking for mining opportunity", blocks_remaining);
 		},
-		Phase::SignedValidation(_) => {
-			log::trace!(target: LOG_TARGET, "In SignedValidation phase - no mining needed");
-			return Ok(());
-		},
 		_ => {
 			log::trace!(target: LOG_TARGET, "Phase {:?} - nothing to do", phase);
 			return Ok(());

--- a/src/commands/multi_block/monitor.rs
+++ b/src/commands/multi_block/monitor.rs
@@ -23,6 +23,15 @@ use std::collections::HashSet;
 
 use tokio::sync::mpsc;
 
+async fn signed_phase(client: &Client, listen: Listen) -> Result<bool, Error> {
+	let storage = utils::storage_at_head(client, listen).await?;
+	let current_phase = storage
+		.fetch_or_default(&runtime::storage().multi_block_election().current_phase())
+		.await?;
+
+	Ok(matches!(current_phase, Phase::Signed(_)))
+}
+
 /// Message types for communication between listener and miner
 enum MinerMessage {
 	/// Request to process a block with given details
@@ -337,6 +346,7 @@ where
 					submission_strategy: config.submission_strategy,
 					do_reduce: config.do_reduce,
 					chunk_size: config.chunk_size,
+					min_signed_phase_blocks: config.min_signed_phase_blocks,
 				};
 				let result = process_block::<T>(
 					client.clone(),
@@ -391,6 +401,7 @@ struct ProcessConfig {
 	submission_strategy: SubmissionStrategy,
 	do_reduce: bool,
 	chunk_size: usize,
+	min_signed_phase_blocks: u32,
 }
 
 async fn process_block<T>(
@@ -426,8 +437,21 @@ where
 			dynamic::fetch_missing_snapshots_lossy::<T>(snapshot, &storage, round).await?;
 			return Ok(());
 		},
-		Phase::Signed(_) => {
-			log::trace!(target: LOG_TARGET, "Signed phase - checking for mining opportunity");
+		Phase::Signed(blocks_remaining) => {
+			if blocks_remaining <= config.min_signed_phase_blocks {
+				log::info!(
+					target: LOG_TARGET,
+					"Signed phase has only {} blocks remaining (need at least {}), skipping mining to avoid incomplete submission",
+					blocks_remaining,
+					config.min_signed_phase_blocks
+				);
+				return Ok(());
+			}
+			log::trace!(target: LOG_TARGET, "Signed phase with {} blocks remaining - checking for mining opportunity", blocks_remaining);
+		},
+		Phase::SignedValidation(_) => {
+			log::trace!(target: LOG_TARGET, "In SignedValidation phase - no mining needed");
+			return Ok(());
 		},
 		_ => {
 			log::trace!(target: LOG_TARGET, "Phase {:?} - nothing to do", phase);
@@ -489,6 +513,13 @@ where
 				return Ok(());
 			}
 			log::debug!(target: LOG_TARGET, "Reverting previous submission to submit better solution");
+
+			// Verify we're still in signed phase before bailing
+			if !signed_phase(&client, listen).await? {
+				log::warn!(target: LOG_TARGET, "Phase changed, cannot bail existing submission");
+				return Ok(());
+			}
+
 			dynamic::bail(&client, &signer, listen).await?;
 		},
 		CurrentSubmission::Incomplete(s) => {
@@ -508,6 +539,7 @@ where
 						missing_pages,
 						listen,
 						round,
+						config.min_signed_phase_blocks,
 					)
 					.await?;
 				} else {
@@ -518,6 +550,7 @@ where
 						listen,
 						config.chunk_size,
 						round,
+						config.min_signed_phase_blocks,
 					)
 					.await?;
 				}
@@ -525,6 +558,13 @@ where
 			}
 
 			log::debug!(target: LOG_TARGET, "Reverting incomplete submission to submit new solution");
+
+			// Verify we're still in signed phase before bailing
+			if !signed_phase(&client, listen).await? {
+				log::warn!(target: LOG_TARGET, "Phase changed, cannot bail incomplete submission");
+				return Ok(());
+			}
+
 			dynamic::bail(&client, &signer, listen).await?;
 		},
 		CurrentSubmission::NotStarted => {
@@ -544,9 +584,17 @@ where
 	log::info!(target: LOG_TARGET, "Submitting solution with score {:?} for round {}", paged_raw_solution.score, round);
 
 	// Submit the solution
-	match dynamic::submit(&client, &signer, paged_raw_solution, listen, config.chunk_size, round)
-		.timed()
-		.await
+	match dynamic::submit(
+		&client,
+		&signer,
+		paged_raw_solution,
+		listen,
+		config.chunk_size,
+		round,
+		config.min_signed_phase_blocks,
+	)
+	.timed()
+	.await
 	{
 		(Ok(_), dur) => {
 			log::info!(

--- a/src/commands/multi_block/monitor.rs
+++ b/src/commands/multi_block/monitor.rs
@@ -439,7 +439,7 @@ where
 		},
 		Phase::Signed(blocks_remaining) => {
 			if blocks_remaining <= config.min_signed_phase_blocks {
-				log::info!(
+				log::trace!(
 					target: LOG_TARGET,
 					"Signed phase has only {} blocks remaining (need at least {}), skipping mining to avoid incomplete submission",
 					blocks_remaining,

--- a/src/commands/types.rs
+++ b/src/commands/types.rs
@@ -88,6 +88,6 @@ pub struct MultiBlockMonitorConfig {
 	/// Minimum number of blocks required in the signed phase before submitting a solution.
 	/// If the signed phase has fewer blocks remaining, the miner will skip mining to avoid
 	/// incomplete submissions and will bail any existing incomplete submissions.
-	#[clap(long, default_value_t = 10)]
+	#[clap(long, default_value_t = 10, value_parser = clap::value_parser!(u32).range(1..))]
 	pub min_signed_phase_blocks: u32,
 }

--- a/src/commands/types.rs
+++ b/src/commands/types.rs
@@ -84,4 +84,10 @@ pub struct MultiBlockMonitorConfig {
 	/// submitting the next chunk.
 	#[clap(long, default_value_t = 0)]
 	pub chunk_size: usize,
+
+	/// Minimum number of blocks required in the signed phase before submitting a solution.
+	/// If the signed phase has fewer blocks remaining, the miner will skip mining to avoid
+	/// incomplete submissions and will bail any existing incomplete submissions.
+	#[clap(long, default_value_t = 10)]
+	pub min_signed_phase_blocks: u32,
 }

--- a/src/dynamic/multi_block.rs
+++ b/src/dynamic/multi_block.rs
@@ -570,7 +570,7 @@ async fn submit_pages_batch<T: MinerConfig + 'static>(
 					{
 						let page = solution_stored.2;
 
-						log::info!(
+						log::debug!(
 							target: LOG_TARGET,
 							"Page {page} included in block {:?}",
 							hash
@@ -781,7 +781,7 @@ async fn validate_signed_phase_or_bail(
 					if submitted_pages < n_pages as usize {
 						log::info!(
 							target: LOG_TARGET,
-							"Bailing incomplete submission for round {} ({}/{} pages submitted) due to insufficient time",
+							"Bailing incomplete submission for round {} ({}/{} pages submitted) due to insufficient signed blocks remaining",
 							round,
 							submitted_pages,
 							n_pages
@@ -794,9 +794,9 @@ async fn validate_signed_phase_or_bail(
 
 				Ok(false)
 			} else {
-				log::debug!(
+				log::trace!(
 					target: LOG_TARGET,
-					"Signed phase has {} blocks remaining, sufficient time to continue",
+					"Signed phase has {} blocks remaining, enough blocks to continue",
 					blocks_remaining
 				);
 				Ok(true)

--- a/src/dynamic/multi_block.rs
+++ b/src/dynamic/multi_block.rs
@@ -792,7 +792,7 @@ async fn validate_signed_phase_or_bail(
 					}
 				}
 
-				return Ok(false);
+				Ok(false)
 			} else {
 				log::debug!(
 					target: LOG_TARGET,

--- a/src/dynamic/multi_block.rs
+++ b/src/dynamic/multi_block.rs
@@ -805,38 +805,10 @@ async fn validate_signed_phase_or_bail(
 		_ => {
 			log::warn!(
 				target: LOG_TARGET,
-				"Phase changed from Signed to {:?} during submission for round {} - cannot bail",
+				"Phase changed from Signed to {:?} during submission for round {}",
 				current_phase,
 				round
 			);
-
-			// Check if we have a partial submission - we can only log it since bail is not possible
-			let maybe_submission = storage
-				.fetch(
-					&runtime::storage()
-						.multi_block_election_signed()
-						.submission_metadata_storage(round, signer.account_id()),
-				)
-				.await?;
-
-			if let Some(submission) = maybe_submission {
-				// We have a submission - check if it's incomplete
-				let n_pages = crate::static_types::multi_block::Pages::get();
-				let submitted_pages: usize =
-					submission.pages.0.iter().map(|&b| if b { 1 } else { 0 }).sum();
-
-				if submitted_pages < n_pages as usize {
-					log::warn!(
-						target: LOG_TARGET,
-						"Found incomplete submission for round {} ({}/{} pages submitted) but cannot bail in phase {:?}",
-						round,
-						submitted_pages,
-						n_pages,
-						current_phase
-					);
-				}
-			}
-
 			Ok(false)
 		},
 	}

--- a/src/dynamic/multi_block.rs
+++ b/src/dynamic/multi_block.rs
@@ -802,45 +802,10 @@ async fn validate_signed_phase_or_bail(
 				Ok(true)
 			}
 		},
-		Phase::SignedValidation(_) => {
-			log::warn!(
-				target: LOG_TARGET,
-				"Phase is now SignedValidation during submission for round {} - cannot bail (only possible in signed phase)",
-				round
-			);
-
-			// Check if we have a partial submission - we can only log it since bail is not possible
-			let maybe_submission = storage
-				.fetch(
-					&runtime::storage()
-						.multi_block_election_signed()
-						.submission_metadata_storage(round, signer.account_id()),
-				)
-				.await?;
-
-			if let Some(submission) = maybe_submission {
-				// We have a submission - check if it's incomplete
-				let n_pages = crate::static_types::multi_block::Pages::get();
-				let submitted_pages: usize =
-					submission.pages.0.iter().map(|&b| if b { 1 } else { 0 }).sum();
-
-				if submitted_pages < n_pages as usize {
-					log::warn!(
-						target: LOG_TARGET,
-						"Found incomplete submission for round {} ({}/{} pages submitted) but cannot bail in SignedValidation phase",
-						round,
-						submitted_pages,
-						n_pages
-					);
-				}
-			}
-
-			Ok(false)
-		},
 		_ => {
 			log::warn!(
 				target: LOG_TARGET,
-				"Phase changed from Signed to {:?} during submission for round {} - cannot bail (only possible in signed phase)",
+				"Phase changed from Signed to {:?} during submission for round {} - cannot bail",
 				current_phase,
 				round
 			);

--- a/src/main.rs
+++ b/src/main.rs
@@ -265,7 +265,8 @@ mod tests {
 				listen: Listen::Finalized,                          // Default
 				submission_strategy: SubmissionStrategy::IfLeading, // Default
 				do_reduce: true,
-				chunk_size: 0, // Default
+				chunk_size: 0,               // Default
+				min_signed_phase_blocks: 10, // Default
 			}),
 		});
 	}
@@ -289,8 +290,9 @@ mod tests {
 				seed_or_path: "//Alice".to_string(),
 				listen: Listen::Finalized,
 				submission_strategy: SubmissionStrategy::IfLeading,
-				do_reduce: false, // Default
-				chunk_size: 0,    // Default
+				do_reduce: false,            // Default
+				chunk_size: 0,               // Default
+				min_signed_phase_blocks: 10, // Default
 			})
 		);
 	}
@@ -315,8 +317,36 @@ mod tests {
 				seed_or_path: "//Alice".to_string(),
 				listen: Listen::Finalized,
 				submission_strategy: SubmissionStrategy::IfLeading,
-				do_reduce: false, // Default
-				chunk_size: 4,    // Explicitly set
+				do_reduce: false,            // Default
+				chunk_size: 4,               // Explicitly set
+				min_signed_phase_blocks: 10, // Default
+			})
+		);
+	}
+
+	#[test]
+	fn cli_monitor_with_min_signed_phase_blocks_works() {
+		let opt = Opt::try_parse_from([
+			env!("CARGO_PKG_NAME"),
+			"--uri",
+			"hi",
+			"monitor",
+			"--seed-or-path",
+			"//Alice",
+			"--min-signed-phase-blocks",
+			"5",
+		])
+		.unwrap();
+
+		assert_eq!(
+			opt.command,
+			Command::Monitor(MultiBlockMonitorConfig {
+				seed_or_path: "//Alice".to_string(),
+				listen: Listen::Finalized,
+				submission_strategy: SubmissionStrategy::IfLeading,
+				do_reduce: false,           // Default
+				chunk_size: 0,              // Default
+				min_signed_phase_blocks: 5, // Explicitly set
 			})
 		);
 	}


### PR DESCRIPTION
The changes add validation to ensure there are enough blocks remaining in the signed phase before attempting solution submission. 

This helps prevent incomplete submissions by requiring a minimum number of blocks (default 10) to complete all pages.

The validation checks remaining blocks before starting submission and between page chunks. If there’s insufficient time, it bails any incomplete submissions and skips mining new solutions.

Example:
```bash
./target/release/polkadot-staking-miner --uri ws://127.0.0.1:9946 monitor --seed-or-path //Alice --min-signed-phase-block 5
```

Close #1083.