### PR TITLE
Added janitor task for automatic deposit recovery with Prometheus metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ The miner consists of **three independent tasks** that communicate via bounded c
 ### Task Communication
 
 ```
-
+                      (finalized blocks)
 ┌──────────────────────────────────────────────────────────────────────────┐
 │   ┌─────────────┐                      ┌─────────────┐            ┌─────────────┐
 └──▶│ Listener    │                      │   Miner     │            │ Blockchain  │

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ The miner automatically handles deposit recovery for discarded submissions:
   winners
 - **Deposit Recovery**: Calls `clear_old_round_data()` to reclaim locked deposits from discarded
   solutions
-- **Triggered on Phase Transitions**: Activates when transitioning from Done/Export to Off phase
+- **Triggered on Round Increments**: Activates when the election round number increments
 
 This ensures that deposits from unsuccessful submissions are automatically recovered, maintaining
 the economic viability of long-term mining operations.
@@ -309,7 +309,7 @@ The miner consists of **three independent tasks** that communicate via bounded c
     │        ▼        │                       └─────────────────┘                │                 │
     │ ┌─────────────┐ │    bounded ch(1)      ┌─────────────────┐                │                 │
     │ │Phase Check  │ │ ─────────────────────▶│  Janitor Task   │                │                 │
-    │ │(fast)       │ │ Done/Extract(0)->Off  │                 │                │                 │
+    │ │(fast)       │ │ Round Increment       │                 │                │                 │
     │ └─────────────┘ │                       │ ┌─────────────┐ │  (cleanup)     │                 │
     │                 │                       │ │   Cleanup   │ │ ──────────────▶│                 │
     │                 │                       │ │ Old Rounds  │ │                │                 │

--- a/src/commands/multi_block/types.rs
+++ b/src/commands/multi_block/types.rs
@@ -98,11 +98,9 @@ impl BlockDetails {
 		at: Header,
 		phase: Phase,
 		block_hash: Hash,
+		round: u32,
 	) -> Result<Self, Error> {
 		let storage = utils::storage_at(Some(block_hash), client.chain_api()).await?;
-		let round = storage
-			.fetch_or_default(&runtime::storage().multi_block_election().round())
-			.await?;
 
 		let desired_targets = storage
 			.fetch(&runtime::storage().multi_block_election().desired_targets(round))

--- a/src/prometheus.rs
+++ b/src/prometheus.rs
@@ -164,6 +164,46 @@ mod hidden {
 		.unwrap()
 	});
 
+	static JANITOR_CLEANUP_SUCCESS: Lazy<Counter> = Lazy::new(|| {
+		register_counter!(opts!(
+			"staking_miner_janitor_cleanup_success_total",
+			"Total number of successful janitor cleanup operations"
+		))
+		.unwrap()
+	});
+
+	static JANITOR_CLEANUP_FAILURES: Lazy<Counter> = Lazy::new(|| {
+		register_counter!(opts!(
+			"staking_miner_janitor_cleanup_failures_total",
+			"Total number of failed janitor cleanup operations"
+		))
+		.unwrap()
+	});
+
+	static JANITOR_OLD_SUBMISSIONS_FOUND: Lazy<Gauge> = Lazy::new(|| {
+		register_gauge!(opts!(
+			"staking_miner_janitor_old_submissions_found",
+			"Number of old submissions found during last janitor run"
+		))
+		.unwrap()
+	});
+
+	static JANITOR_OLD_SUBMISSIONS_CLEARED: Lazy<Gauge> = Lazy::new(|| {
+		register_gauge!(opts!(
+			"staking_miner_janitor_old_submissions_cleared",
+			"Number of old submissions successfully cleared during last janitor run"
+		))
+		.unwrap()
+	});
+
+	static JANITOR_CLEANUP_DURATION: Lazy<Gauge> = Lazy::new(|| {
+		register_gauge!(
+			"staking_miner_janitor_cleanup_duration_ms",
+			"The time in milliseconds it takes to complete janitor cleanup"
+		)
+		.unwrap()
+	});
+
 	pub fn on_runtime_upgrade() {
 		RUNTIME_UPGRADES.inc();
 	}
@@ -192,5 +232,22 @@ mod hidden {
 
 	pub fn on_submission_success() {
 		SUBMISSIONS_SUCCESS.inc();
+	}
+
+	pub fn on_janitor_cleanup_success(cleared_count: u32) {
+		JANITOR_CLEANUP_SUCCESS.inc();
+		JANITOR_OLD_SUBMISSIONS_CLEARED.set(cleared_count as f64);
+	}
+
+	pub fn on_janitor_cleanup_failure() {
+		JANITOR_CLEANUP_FAILURES.inc();
+	}
+
+	pub fn set_janitor_old_submissions_found(count: u32) {
+		JANITOR_OLD_SUBMISSIONS_FOUND.set(count as f64);
+	}
+
+	pub fn observe_janitor_cleanup_duration(time: f64) {
+		JANITOR_CLEANUP_DURATION.set(time);
 	}
 }


### PR DESCRIPTION
Implements automatic cleanup of old discarded submissions to reclaim deposits.
Close #980.

## Features:
- Triggers when the election round increments (runs once per new round)
- Scans the last 5 rounds for old submissions at most (the usual process is to simply clear the previous round).
- Calls `clear_old_round_data()` to recover deposits and clean storage
- Non-blocking integration with existing mining operations
- Comprehensive error handling (critical vs recoverable errors)

## Architecture

 - Introduce `JanitorMessage` enum and `janitor_task` for deposit recovery 
 - Use dedicated bounded channel for janitor communication 
 - Update listener to send janitor ticks to janitor task 
 - Ensure mining and janitor operations are independent and non-blocking

```
┌──────────────────────────────────────────────────────────────────────────┐
│   ┌─────────────┐                      ┌─────────────┐            ┌─────────────┐
└──▶│ Listener    │                      │   Miner     │            │ Blockchain  │
    │             │  Snapshot/Signed     │             │            │             │
    │ ┌─────────┐ │ ────────────────────▶│ ┌─────────┐ │ (solutions)│             │
    │ │ Stream  │ │  (mining work)       │ │ Mining  │ │───────────▶│             │
    │ └─────────┘ │                      │ └─────────┘ │            │             │
    │      │      │  Round++             │ ┌─────────┐ │            │             │
    │      ▼      │ ────────────────────▶│ │ Clear   │ │            │             │
    │ ┌─────────┐ │                      │ │ Snapshot│ │            │             │
    │ │ Phase   │ │                      │ └─────────┘ │            │             │
    │ │ Check   │ │  Round++             └─────────────┘            │             │
    │ └─────────┘ │ ────────────────────▶┌─────────────┐            │             │
    │             │  (deposit cleanup)   │  Janitor    │ (cleanup)  │             │
    │             │                      │ ┌─────────┐ │───────────▶│             │
    │             │                      │ │ Cleanup │ │            │             │
    │             │                      │ └─────────┘ │            │             │
    └─────────────┘                      └─────────────┘            └─────────────┘

```

## Prometheus Metrics Added:

### Counters:
- staking_miner_janitor_cleanup_success_total: Successful cleanup operations
- staking_miner_janitor_cleanup_failures_total: Failed cleanup operations

### Gauges:
- staking_miner_janitor_cleanup_duration_ms: Time taken for last cleanup
- staking_miner_janitor_old_submissions_found: Old submissions discovered
- staking_miner_janitor_old_submissions_cleared: Submissions successfully cleared

### Key Metrics:
- Success rate: success_total / (success_total + failures_total)
- Performance: avg(cleanup_duration_ms)
- Activity: old_submissions_cleared shows actual deposit recovery

### Example Prometheus queries:
```
staking_miner_janitor_cleanup_success_total / (staking_miner_janitor_cleanup_success_total + staking_miner_janitor_cleanup_failures_total)

increase(staking_miner_janitor_cleanup_success_total[24h])

staking_miner_janitor_old_submissions_cleared / staking_miner_janitor_old_submissions_found
```

## Logs

An example of logs below when a previous submission is cleared

```log
2025-06-20T20:09:03.221683Z DEBUG polkadot-staking-miner: Detected round increment 9 -> 10    
2025-06-20T20:09:03.221707Z TRACE polkadot-staking-miner: Sent janitor tick for round 10    
2025-06-20T20:09:03.221711Z DEBUG polkadot-staking-miner: Round increment in Off phase, signaling snapshot cleanup    
2025-06-20T20:09:03.221718Z TRACE polkadot-staking-miner: Block #792, Phase Off - nothing to do    
2025-06-20T20:09:03.221731Z TRACE polkadot-staking-miner: Running janitor cleanup for round 10    
2025-06-20T20:09:03.221745Z TRACE polkadot-staking-miner: Clearing snapshots    
2025-06-20T20:09:03.221749Z TRACE polkadot-staking-miner: Scanning round 9 for old submissions (current round: 10, scanning rounds from 9)    
2025-06-20T20:09:03.222313Z DEBUG polkadot-staking-miner: Found old submission in round 9 with 4 pages, attempting cleanup    
2025-06-20T20:09:03.222324Z DEBUG polkadot-staking-miner: Clearing old round data for round 9 with 4 witness pages    
2025-06-20T20:09:11.232603Z TRACE polkadot-staking-miner: Block #793, Phase Off - nothing to do    
2025-06-20T20:09:15.243377Z TRACE polkadot-staking-miner: Block #794, Phase Off - nothing to do    
2025-06-20T20:09:23.253658Z TRACE polkadot-staking-miner: Block #795, Phase Off - nothing to do    
2025-06-20T20:09:27.257928Z TRACE polkadot-staking-miner: Block #796, Phase Off - nothing to do    
2025-06-20T20:09:35.275623Z TRACE polkadot-staking-miner: Block #797, Phase Off - nothing to do    
2025-06-20T20:09:39.278849Z DEBUG polkadot-staking-miner: Successfully submitted clear_old_round_data for round 9    
2025-06-20T20:09:39.278892Z  INFO polkadot-staking-miner: Successfully cleaned up old submission from round 9 (4 witness pages)    
2025-06-20T20:09:39.278901Z  INFO polkadot-staking-miner: Janitor cleaned up 1 old submissions in 36057ms    
```

## Integration test

An integration test now verifies the scenario where two miners submit identical solutions. Both solutions are successfully submitted; one is rewarded while the other is discarded after `clear_old_round()` has been explicitly called by the miner with the non-winning solution.

```log
2025-06-20T13:13:08.930566Z  INFO monitor: Bob solution discarded!    
2025-06-20T13:13:08.998134Z  INFO monitor: 🤑 Successfully completed two-miner test: both submitted solutions, one rewarded, one discarded! Duration: 1179.356788208s 🤑    
test submit_works ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1179.38s
```
