### PR TITLE
Track SDK's master branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -885,7 +885,7 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 [[package]]
 name = "asset-test-utils"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-xcmp-queue",
@@ -915,7 +915,7 @@ dependencies = [
 [[package]]
 name = "assets-common"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "cumulus-primitives-core",
  "ethereum-standards",
@@ -1147,7 +1147,7 @@ checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
 [[package]]
 name = "binary-merkle-tree"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "hash-db",
  "log",
@@ -1364,7 +1364,7 @@ dependencies = [
 [[package]]
 name = "bp-header-chain"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "bp-runtime",
  "finality-grandpa",
@@ -1381,7 +1381,7 @@ dependencies = [
 [[package]]
 name = "bp-messages"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "bp-header-chain",
  "bp-runtime",
@@ -1397,7 +1397,7 @@ dependencies = [
 [[package]]
 name = "bp-parachains"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "bp-header-chain",
  "bp-polkadot-core",
@@ -1414,7 +1414,7 @@ dependencies = [
 [[package]]
 name = "bp-polkadot-core"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -1431,7 +1431,7 @@ dependencies = [
 [[package]]
 name = "bp-relayers"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -1449,7 +1449,7 @@ dependencies = [
 [[package]]
 name = "bp-runtime"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1472,7 +1472,7 @@ dependencies = [
 [[package]]
 name = "bp-test-utils"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "bp-header-chain",
  "bp-parachains",
@@ -1492,7 +1492,7 @@ dependencies = [
 [[package]]
 name = "bp-xcm-bridge-hub"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -1509,7 +1509,7 @@ dependencies = [
 [[package]]
 name = "bp-xcm-bridge-hub-router"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -1521,7 +1521,7 @@ dependencies = [
 [[package]]
 name = "bridge-hub-common"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -1540,7 +1540,7 @@ dependencies = [
 [[package]]
 name = "bridge-hub-test-utils"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "asset-test-utils",
  "bp-header-chain",
@@ -1582,7 +1582,7 @@ dependencies = [
 [[package]]
 name = "bridge-runtime-common"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -2148,7 +2148,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-aura-ext"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -2165,7 +2165,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-dmp-queue"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "cumulus-primitives-core",
  "frame-benchmarking",
@@ -2182,7 +2182,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "bytes",
  "cumulus-pallet-parachain-system-proc-macro",
@@ -2219,7 +2219,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2230,7 +2230,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-session-benchmarking"
 version = "9.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2243,7 +2243,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-solo-to-para"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -2258,7 +2258,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-weight-reclaim"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "cumulus-primitives-storage-weight-reclaim",
  "derive-where",
@@ -2277,7 +2277,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcm"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -2292,7 +2292,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
 version = "0.7.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "approx",
  "bounded-collections 0.2.4",
@@ -2318,7 +2318,7 @@ dependencies = [
 [[package]]
 name = "cumulus-ping"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "cumulus-pallet-xcm",
  "cumulus-primitives-core",
@@ -2333,7 +2333,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-aura"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "sp-api",
  "sp-consensus-aura",
@@ -2342,7 +2342,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -2359,7 +2359,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2373,7 +2373,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "sp-externalities",
  "sp-runtime-interface",
@@ -2383,7 +2383,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-storage-weight-reclaim"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-proof-size-hostfunction",
@@ -2400,7 +2400,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-timestamp"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "cumulus-primitives-core",
  "sp-inherents",
@@ -2410,7 +2410,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-utility"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -2427,7 +2427,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -2946,7 +2946,7 @@ dependencies = [
 [[package]]
 name = "ethereum-standards"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "alloy-core",
 ]
@@ -3141,7 +3141,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -3165,7 +3165,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-pallet-pov"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3207,7 +3207,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -3218,7 +3218,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -3235,7 +3235,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "aquamarine",
  "frame-support",
@@ -3287,7 +3287,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata-hash-extension"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "array-bytes",
  "const-hex",
@@ -3303,7 +3303,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "aquamarine",
  "array-bytes",
@@ -3344,7 +3344,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -3357,14 +3357,14 @@ dependencies = [
  "proc-macro-warning",
  "proc-macro2",
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "syn 2.0.100",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -3376,7 +3376,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3386,7 +3386,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "cfg-if",
  "docify",
@@ -3405,7 +3405,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3419,7 +3419,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -3429,7 +3429,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4984,7 +4984,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "pallet-alliance"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4995,7 +4995,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "sp-io",
  "sp-runtime",
 ]
@@ -5003,7 +5003,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-conversion"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5021,7 +5021,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-conversion-ops"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5039,7 +5039,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-conversion-tx-payment"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5054,7 +5054,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-rate"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5068,7 +5068,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-rewards"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5086,7 +5086,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-tx-payment"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5102,7 +5102,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets"
 version = "29.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "ethereum-standards",
  "frame-benchmarking",
@@ -5120,7 +5120,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets-freezer"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "log",
  "pallet-assets",
@@ -5132,7 +5132,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets-holder"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5147,7 +5147,7 @@ dependencies = [
 [[package]]
 name = "pallet-atomic-swap"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -5157,7 +5157,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5173,7 +5173,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5188,7 +5188,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5201,7 +5201,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5224,7 +5224,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "aquamarine",
  "docify",
@@ -5245,7 +5245,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -5261,7 +5261,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5280,7 +5280,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "array-bytes",
  "binary-merkle-tree",
@@ -5305,7 +5305,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5322,7 +5322,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-grandpa"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "bp-header-chain",
  "bp-runtime",
@@ -5341,7 +5341,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-messages"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -5360,7 +5360,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-parachains"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "bp-header-chain",
  "bp-parachains",
@@ -5380,7 +5380,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-relayers"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -5403,7 +5403,7 @@ dependencies = [
 [[package]]
 name = "pallet-broker"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -5421,7 +5421,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5439,7 +5439,7 @@ dependencies = [
 [[package]]
 name = "pallet-collator-selection"
 version = "9.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5458,7 +5458,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -5475,7 +5475,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective-content"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5489,7 +5489,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -5519,7 +5519,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-mock-network"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5550,7 +5550,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-proc-macro"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5560,7 +5560,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-uapi"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -5571,7 +5571,7 @@ dependencies = [
 [[package]]
 name = "pallet-conviction-voting"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -5587,7 +5587,7 @@ dependencies = [
 [[package]]
 name = "pallet-core-fellowship"
 version = "12.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5605,7 +5605,7 @@ dependencies = [
 [[package]]
 name = "pallet-delegated-staking"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5620,7 +5620,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5637,7 +5637,7 @@ dependencies = [
 [[package]]
 name = "pallet-dev-mode"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5652,7 +5652,7 @@ dependencies = [
 [[package]]
 name = "pallet-dummy-dim"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5670,7 +5670,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-block"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5691,7 +5691,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5712,7 +5712,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5725,7 +5725,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5743,7 +5743,7 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -5761,7 +5761,7 @@ dependencies = [
 [[package]]
 name = "pallet-glutton"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "blake2",
  "frame-benchmarking",
@@ -5779,7 +5779,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5801,7 +5801,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -5817,7 +5817,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5836,7 +5836,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5851,7 +5851,7 @@ dependencies = [
 [[package]]
 name = "pallet-insecure-randomness-collective-flip"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -5862,7 +5862,7 @@ dependencies = [
 [[package]]
 name = "pallet-lottery"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5875,7 +5875,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5891,7 +5891,7 @@ dependencies = [
 [[package]]
 name = "pallet-message-queue"
 version = "31.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -5910,7 +5910,7 @@ dependencies = [
 [[package]]
 name = "pallet-meta-tx"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -5928,7 +5928,7 @@ dependencies = [
 [[package]]
 name = "pallet-migrations"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -5947,7 +5947,7 @@ dependencies = [
 [[package]]
 name = "pallet-mixnet"
 version = "0.4.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -5961,7 +5961,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -5973,7 +5973,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -5984,7 +5984,7 @@ dependencies = [
 [[package]]
 name = "pallet-nft-fractionalization"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "log",
  "pallet-assets",
@@ -5997,7 +5997,7 @@ dependencies = [
 [[package]]
 name = "pallet-nfts"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -6014,7 +6014,7 @@ dependencies = [
 [[package]]
 name = "pallet-nfts-runtime-api"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6023,7 +6023,7 @@ dependencies = [
 [[package]]
 name = "pallet-nis"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -6033,7 +6033,7 @@ dependencies = [
 [[package]]
 name = "pallet-node-authorization"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -6044,7 +6044,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools"
 version = "25.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6062,7 +6062,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6082,7 +6082,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
@@ -6092,7 +6092,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6107,7 +6107,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6130,7 +6130,7 @@ dependencies = [
 [[package]]
 name = "pallet-origin-restriction"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6148,7 +6148,7 @@ dependencies = [
 [[package]]
 name = "pallet-paged-list"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -6160,7 +6160,7 @@ dependencies = [
 [[package]]
 name = "pallet-parameters"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -6177,7 +6177,7 @@ dependencies = [
 [[package]]
 name = "pallet-people"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6195,7 +6195,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6211,7 +6211,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -6221,7 +6221,7 @@ dependencies = [
 [[package]]
 name = "pallet-ranked-collective"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6239,7 +6239,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -6249,7 +6249,7 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6266,7 +6266,7 @@ dependencies = [
 [[package]]
 name = "pallet-remark"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6282,7 +6282,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "alloy-core",
  "derive_more 0.99.19",
@@ -6305,8 +6305,8 @@ dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
  "paste",
- "polkavm 0.21.0",
- "polkavm-common 0.21.0",
+ "polkavm",
+ "polkavm-common",
  "rand 0.8.5",
  "ripemd",
  "rlp 0.6.1",
@@ -6327,7 +6327,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive-fixtures"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -6341,7 +6341,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6351,19 +6351,19 @@ dependencies = [
 [[package]]
 name = "pallet-revive-uapi"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "bitflags 1.3.2",
  "pallet-revive-proc-macro",
  "parity-scale-codec",
- "polkavm-derive 0.21.0",
+ "polkavm-derive",
  "scale-info",
 ]
 
 [[package]]
 name = "pallet-root-offences"
 version = "25.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6379,7 +6379,7 @@ dependencies = [
 [[package]]
 name = "pallet-root-testing"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6392,7 +6392,7 @@ dependencies = [
 [[package]]
 name = "pallet-safe-mode"
 version = "9.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "docify",
  "pallet-balances",
@@ -6406,7 +6406,7 @@ dependencies = [
 [[package]]
 name = "pallet-salary"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "log",
  "pallet-ranked-collective",
@@ -6418,7 +6418,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -6435,7 +6435,7 @@ dependencies = [
 [[package]]
 name = "pallet-scored-pool"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6448,7 +6448,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6470,7 +6470,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6486,7 +6486,7 @@ dependencies = [
 [[package]]
 name = "pallet-skip-feeless-payment"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6498,7 +6498,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6515,7 +6515,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6536,7 +6536,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-async"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6559,7 +6559,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-async-ah-client"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6578,7 +6578,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-async-rc-client"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6595,7 +6595,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-async-reward-fn"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -6604,7 +6604,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-async-runtime-api"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6614,7 +6614,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -6623,7 +6623,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-runtime-api"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6633,7 +6633,7 @@ dependencies = [
 [[package]]
 name = "pallet-state-trie-migration"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6649,7 +6649,7 @@ dependencies = [
 [[package]]
 name = "pallet-statement"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6666,7 +6666,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -6681,7 +6681,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -6699,7 +6699,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6717,7 +6717,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6732,7 +6732,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -6744,7 +6744,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-storage"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6763,7 +6763,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -6782,7 +6782,7 @@ dependencies = [
 [[package]]
 name = "pallet-tx-pause"
 version = "9.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -6793,7 +6793,7 @@ dependencies = [
 [[package]]
 name = "pallet-uniques"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6807,7 +6807,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6822,7 +6822,7 @@ dependencies = [
 [[package]]
 name = "pallet-verify-signature"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6837,7 +6837,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6851,7 +6851,7 @@ dependencies = [
 [[package]]
 name = "pallet-whitelist"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -6861,7 +6861,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "bounded-collections 0.2.4",
  "frame-benchmarking",
@@ -6886,7 +6886,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-benchmarks"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6903,7 +6903,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-bridge-hub"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -6925,7 +6925,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-bridge-hub-router"
 version = "0.5.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "bp-xcm-bridge-hub-router",
  "frame-benchmarking",
@@ -6945,7 +6945,7 @@ dependencies = [
 [[package]]
 name = "parachains-common"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
@@ -6958,6 +6958,7 @@ dependencies = [
  "pallet-balances",
  "pallet-collator-selection",
  "pallet-message-queue",
+ "pallet-treasury",
  "pallet-xcm",
  "parity-scale-codec",
  "polkadot-primitives",
@@ -6975,7 +6976,7 @@ dependencies = [
 [[package]]
 name = "parachains-runtimes-test-utils"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-xcmp-queue",
@@ -7197,7 +7198,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -7208,7 +7209,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain-primitives"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "bounded-collections 0.2.4",
  "derive_more 0.99.19",
@@ -7224,7 +7225,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "bitvec",
  "bounded-collections 0.2.4",
@@ -7253,7 +7254,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-common"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -7302,7 +7303,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "bs58",
  "frame-benchmarking",
@@ -7314,7 +7315,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
@@ -7361,7 +7362,7 @@ dependencies = [
 [[package]]
 name = "polkadot-sdk"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "asset-test-utils",
  "assets-common",
@@ -7547,7 +7548,7 @@ dependencies = [
  "sp-core",
  "sp-core-hashing",
  "sp-crypto-ec-utils",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "sp-debug-derive",
  "sp-externalities",
  "sp-genesis-builder",
@@ -7588,7 +7589,7 @@ dependencies = [
 [[package]]
 name = "polkadot-sdk-frame"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -7652,106 +7653,53 @@ dependencies = [
 
 [[package]]
 name = "polkavm"
-version = "0.21.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd34e2f74206fff33482ae1718e275f11365ef8c4de7f0e69217f8845303867"
+checksum = "643c98b9cb27449cffe54c2b500fe8d55d7aa7f29acdd90c56e5cd196fe3d728"
 dependencies = [
  "libc",
  "log",
- "polkavm-assembler 0.21.0",
- "polkavm-common 0.21.0",
- "polkavm-linux-raw 0.21.0",
-]
-
-[[package]]
-name = "polkavm"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2a01db119bb3a86572c0641ba6e7c9786fbd2ac89c25b43b688c4e353787526"
-dependencies = [
- "libc",
- "log",
- "polkavm-assembler 0.24.0",
- "polkavm-common 0.24.0",
- "polkavm-linux-raw 0.24.0",
+ "polkavm-assembler",
+ "polkavm-common",
+ "polkavm-linux-raw",
 ]
 
 [[package]]
 name = "polkavm-assembler"
-version = "0.21.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f512bc80cb10439391a7c13a9eb2d37cf66b7305e7df0a06d662eff4f5b07625"
-dependencies = [
- "log",
-]
-
-[[package]]
-name = "polkavm-assembler"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eea6105f3f344abe0bf0151d67b3de6f5d24353f2393355ecf3f5f6e06d7fd0b"
+checksum = "51fcf86a40f3d2191cc2b65357e774eda67875cbc31843f505a69b70f8679922"
 dependencies = [
  "log",
 ]
 
 [[package]]
 name = "polkavm-common"
-version = "0.21.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c16b809cfd398f861261c045a8745e6c78b71ea7e0d3ef6f7cc553eb27bc17e"
+checksum = "28732f89f1e730d908fd816db50ee2afcb8368345ded9f9bc78fbd710db7a4be"
 dependencies = [
  "blake3",
  "log",
- "polkavm-assembler 0.21.0",
-]
-
-[[package]]
-name = "polkavm-common"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed9e5af472f729fcf3b3c1cf17508ddbb3505259dd6e2ee0fb5a29e105d22"
-dependencies = [
- "log",
- "polkavm-assembler 0.24.0",
+ "polkavm-assembler",
 ]
 
 [[package]]
 name = "polkavm-derive"
-version = "0.21.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47239245f87329541932c0d7fec750a66a75b13aa87dfe4fbfd637bab86ad387"
+checksum = "b5de33a198ef311b3ceb8de476515fbb92b4d2ed56feb23499b0875d0e6a8ce6"
 dependencies = [
- "polkavm-derive-impl-macro 0.21.0",
-]
-
-[[package]]
-name = "polkavm-derive"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "176144f8661117ea95fa7cf868c9a62d6b143e8a2ebcb7582464c3faade8669a"
-dependencies = [
- "polkavm-derive-impl-macro 0.24.0",
+ "polkavm-derive-impl-macro",
 ]
 
 [[package]]
 name = "polkavm-derive-impl"
-version = "0.21.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24fd6c6215450c3e57511df5c38a82eb4bde208de15ee15046ac33852f3c3eaa"
+checksum = "dff180bfd5add755ae54197babc79cd6efc3c3d01a5ded643b1ab37a9932deb2"
 dependencies = [
- "polkavm-common 0.21.0",
- "proc-macro2",
- "quote",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "polkavm-derive-impl"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5a21844afdfcc10c92b9ef288ccb926211af27478d1730fcd55e4aec710179d"
-dependencies = [
- "polkavm-common 0.24.0",
+ "polkavm-common",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -7759,51 +7707,35 @@ dependencies = [
 
 [[package]]
 name = "polkavm-derive-impl-macro"
-version = "0.21.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36837f6b7edfd6f4498f8d25d81da16cf03bd6992c3e56f3d477dfc90f4fefca"
+checksum = "0105f050c7bce74fa4327a3e8e5c8a6368e39a7c93c5e8e99b33df90c097c859"
 dependencies = [
- "polkavm-derive-impl 0.21.0",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "polkavm-derive-impl-macro"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba0ef0f17ad81413ea1ca5b1b67553aedf5650c88269b673d3ba015c83bc2651"
-dependencies = [
- "polkavm-derive-impl 0.24.0",
+ "polkavm-derive-impl",
  "syn 2.0.100",
 ]
 
 [[package]]
 name = "polkavm-linker"
-version = "0.21.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23bc764986c4a63f9ab9890c3f4eb9b4c13b6ff80d79685bd48ade147234aab4"
+checksum = "5985c1abf240511baab6424a295b64d61e530dd50069588d1486ef24665f8f34"
 dependencies = [
  "dirs",
  "gimli 0.31.1",
  "hashbrown 0.14.5",
  "log",
  "object 0.36.7",
- "polkavm-common 0.21.0",
+ "polkavm-common",
  "regalloc2 0.9.3",
  "rustc-demangle",
 ]
 
 [[package]]
 name = "polkavm-linux-raw"
-version = "0.21.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be6cd1d48c5e7814d287a3e12a339386a5dfa2f3ac72f932335f4cf56467f1b3"
-
-[[package]]
-name = "polkavm-linux-raw"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec0b13e26ec7234dba213ca17118c70c562809bdce0eefe84f92613d5c8da26"
+checksum = "30993b46019e02b9d3de07e09d84f5b4474244ec966028fa95a38547076ffd93"
 
 [[package]]
 name = "polling"
@@ -8363,7 +8295,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime-constants"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -8640,7 +8572,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "log",
  "sp-core",
@@ -8651,7 +8583,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "parity-scale-codec",
  "parking_lot",
@@ -8674,9 +8606,9 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.29.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
- "polkavm 0.24.0",
+ "polkavm",
  "sc-allocator",
  "sp-maybe-compressed-blob",
  "sp-wasm-interface",
@@ -8687,10 +8619,10 @@ dependencies = [
 [[package]]
 name = "sc-executor-polkavm"
 version = "0.29.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "log",
- "polkavm 0.24.0",
+ "polkavm",
  "sc-executor-common",
  "sp-wasm-interface",
 ]
@@ -8698,7 +8630,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.29.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "anyhow",
  "log",
@@ -9266,7 +9198,7 @@ checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
 [[package]]
 name = "slot-range-helper"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -9390,7 +9322,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-core"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "bp-relayers",
  "frame-support",
@@ -9439,7 +9371,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "docify",
  "hash-db",
@@ -9461,7 +9393,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "Inflector",
  "blake2",
@@ -9475,7 +9407,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "30.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9487,7 +9419,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -9501,7 +9433,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9513,7 +9445,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -9523,7 +9455,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -9539,7 +9471,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -9557,7 +9489,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-beefy"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9565,7 +9497,7 @@ dependencies = [
  "sp-api",
  "sp-application-crypto",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "sp-io",
  "sp-keystore",
  "sp-mmr-primitives",
@@ -9577,7 +9509,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -9594,7 +9526,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-pow"
 version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -9605,7 +9537,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9616,7 +9548,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "ark-vrf",
  "array-bytes",
@@ -9647,7 +9579,7 @@ dependencies = [
  "secrecy 0.8.0",
  "serde",
  "sha2 0.10.8",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "sp-debug-derive",
  "sp-externalities",
  "sp-runtime-interface",
@@ -9664,15 +9596,15 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
 ]
 
 [[package]]
 name = "sp-crypto-ec-utils"
 version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-377-ext",
@@ -9706,7 +9638,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -9719,17 +9651,17 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "syn 2.0.100",
 ]
 
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9739,7 +9671,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.25.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -9749,7 +9681,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9761,7 +9693,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -9774,7 +9706,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "30.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "bytes",
  "docify",
@@ -9782,11 +9714,11 @@ dependencies = [
  "libsecp256k1",
  "log",
  "parity-scale-codec",
- "polkavm-derive 0.24.0",
+ "polkavm-derive",
  "rustversion",
  "secp256k1 0.28.2",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "sp-externalities",
  "sp-keystore",
  "sp-runtime-interface",
@@ -9800,7 +9732,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "31.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -9810,7 +9742,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "parity-scale-codec",
  "parking_lot",
@@ -9821,7 +9753,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "thiserror 1.0.69",
  "zstd 0.12.4",
@@ -9830,7 +9762,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-metadata 23.0.0",
  "parity-scale-codec",
@@ -9840,7 +9772,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.4.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9851,7 +9783,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -9868,7 +9800,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9881,7 +9813,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -9891,7 +9823,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "backtrace",
  "regex",
@@ -9900,7 +9832,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "31.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "binary-merkle-tree",
  "docify",
@@ -9929,12 +9861,12 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
  "parity-scale-codec",
- "polkavm-derive 0.24.0",
+ "polkavm-derive",
  "primitive-types 0.13.1",
  "sp-externalities",
  "sp-runtime-interface-proc-macro",
@@ -9948,7 +9880,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "Inflector",
  "expander",
@@ -9961,7 +9893,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9975,7 +9907,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -9988,7 +9920,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.35.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "hash-db",
  "log",
@@ -10008,7 +9940,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek",
@@ -10021,7 +9953,7 @@ dependencies = [
  "sp-api",
  "sp-application-crypto",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=master)",
  "sp-externalities",
  "sp-runtime",
  "sp-runtime-interface",
@@ -10032,12 +9964,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 
 [[package]]
 name = "sp-storage"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -10049,7 +9981,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -10061,7 +9993,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -10072,7 +10004,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -10081,7 +10013,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -10095,7 +10027,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "ahash",
  "hash-db",
@@ -10118,7 +10050,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -10135,7 +10067,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-warning",
@@ -10147,7 +10079,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -10159,7 +10091,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "bounded-collections 0.2.4",
  "parity-scale-codec",
@@ -10210,7 +10142,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "staging-parachain-info"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -10223,7 +10155,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm"
 version = "7.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "array-bytes",
  "bounded-collections 0.2.4",
@@ -10244,7 +10176,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-builder"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "environmental",
  "frame-support",
@@ -10268,7 +10200,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-executor"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -10333,7 +10265,7 @@ dependencies = [
 [[package]]
 name = "substrate-bip39"
 version = "0.4.7"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
@@ -10358,7 +10290,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -10714,7 +10646,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 [[package]]
 name = "testnet-parachains-constants"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -11746,7 +11678,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime-constants"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -12068,7 +12000,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -12079,7 +12011,7 @@ dependencies = [
 [[package]]
 name = "xcm-runtime-apis"
 version = "0.1.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -12093,7 +12025,7 @@ dependencies = [
 [[package]]
 name = "xcm-simulator"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=donal-ahm#dfe0548c865a4f2ffab163af4523b0e580d1cd5f"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=master#4e122d496f68a820e0e13f63435b6d74fb53be0d"
 dependencies = [
  "frame-support",
  "frame-system",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ polkadot-sdk = { git = "https://github.com/paritytech/polkadot-sdk", features = 
     "sp-runtime",
     "sp-version",
     "pallet-election-provider-multi-block",
-], branch = "donal-ahm" }
+], branch = "master" }
 
 # prometheus
 prometheus = "0.14"


### PR DESCRIPTION
Now that [SDK#7997](https://github.com/paritytech/polkadot-sdk/pull/7997) has been merged, we can track SDK's  `master` branch again instead of `donal-ahm`.