### PR TITLE
Bump to subxt 0.43.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10360,9 +10360,9 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "subxt"
-version = "0.42.1"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c7533d39317bed01100b37158740dcec27c0e1933f3bca19bdf12110f242248"
+checksum = "74791ddeaaa6de42e7cc8a715c83eb73303f513f90af701fd07eb2caad92ed84"
 dependencies = [
  "async-trait",
  "derive-where",
@@ -10381,10 +10381,10 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "subxt-core 0.42.1",
+ "subxt-core 0.43.0",
  "subxt-lightclient",
  "subxt-macro",
- "subxt-metadata 0.42.1",
+ "subxt-metadata 0.43.0",
  "subxt-rpcs",
  "thiserror 2.0.12",
  "tokio",
@@ -10397,9 +10397,9 @@ dependencies = [
 
 [[package]]
 name = "subxt-codegen"
-version = "0.42.1"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ded0fa15fa78c58b91e2a1c6bcef8a2bc68fe165d00e1dfb9787069351511c"
+checksum = "1728caecd9700391e78cc30dc298221d6f5ca0ea28258a452aa76b0b7c229842"
 dependencies = [
  "heck",
  "parity-scale-codec",
@@ -10407,7 +10407,7 @@ dependencies = [
  "quote",
  "scale-info",
  "scale-typegen",
- "subxt-metadata 0.42.1",
+ "subxt-metadata 0.43.0",
  "syn 2.0.100",
  "thiserror 2.0.12",
 ]
@@ -10444,9 +10444,9 @@ dependencies = [
 
 [[package]]
 name = "subxt-core"
-version = "0.42.1"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c3574b60050e57cf23edf6521263b06e98a880073df330813bb04242633083"
+checksum = "25338dd11ae34293b8d0c5807064f2e00194ba1bd84cccfa694030c8d185b941"
 dependencies = [
  "base58",
  "blake2",
@@ -10467,16 +10467,16 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "subxt-metadata 0.42.1",
+ "subxt-metadata 0.43.0",
  "thiserror 2.0.12",
  "tracing",
 ]
 
 [[package]]
 name = "subxt-lightclient"
-version = "0.42.1"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c546d42ca103c0a6a3434cadf4ca500d2a49e60af0842b0fdee6fbfa97aa02f"
+checksum = "9097ef356e534ce0b6a50b95233512afc394347b971a4f929c4830adc52bbc6f"
 dependencies = [
  "futures",
  "futures-util",
@@ -10491,9 +10491,9 @@ dependencies = [
 
 [[package]]
 name = "subxt-macro"
-version = "0.42.1"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91d253492eb17c65bdb41e538d6a31508563757bd34ad6014cb03536cf31757"
+checksum = "69516e8ff0e9340a0f21b8398da7f997571af4734ee81deada5150a2668c8443"
 dependencies = [
  "darling",
  "parity-scale-codec",
@@ -10501,7 +10501,7 @@ dependencies = [
  "quote",
  "scale-typegen",
  "subxt-codegen",
- "subxt-metadata 0.42.1",
+ "subxt-metadata 0.43.0",
  "subxt-utils-fetchmetadata",
  "syn 2.0.100",
 ]
@@ -10523,9 +10523,9 @@ dependencies = [
 
 [[package]]
 name = "subxt-metadata"
-version = "0.42.1"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243990ca4e0cdb74ef7458f1d5070a1bd5144d744cc146f23a32ab56d23e1db7"
+checksum = "2c134068711c0c46906abc0e6e4911204420331530738e18ca903a5469364d9f"
 dependencies = [
  "frame-decode 0.8.0",
  "frame-metadata 23.0.0",
@@ -10538,9 +10538,9 @@ dependencies = [
 
 [[package]]
 name = "subxt-rpcs"
-version = "0.42.1"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55313e3652f5360b5ed878bfe1d62fe181ecb8c130c81278ab89d1580f89a7ed"
+checksum = "25de7727144780d780a6a7d78bbfd28414b8adbab68b05e87329c367d7705be4"
 dependencies = [
  "derive-where",
  "finito",
@@ -10553,7 +10553,7 @@ dependencies = [
  "primitive-types 0.13.1",
  "serde",
  "serde_json",
- "subxt-core 0.42.1",
+ "subxt-core 0.43.0",
  "subxt-lightclient",
  "thiserror 2.0.12",
  "tokio",
@@ -10594,9 +10594,9 @@ dependencies = [
 
 [[package]]
 name = "subxt-utils-fetchmetadata"
-version = "0.42.1"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62d3a6e9cb2fd2db8bf3cb0d03da691ac949259e620c9eb8f25764b2711805ca"
+checksum = "8c4fb8fd6b16ecd3537a29d70699f329a68c1e47f70ed1a46d64f76719146563"
 dependencies = [
  "hex",
  "parity-scale-codec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,37 +22,37 @@ serde_json = "1.0"
 futures = "0.3"
 thiserror = "2.0"
 tokio = { version = "1.46", features = [
-    "macros",
-    "rt-multi-thread",
-    "sync",
-    "signal",
+  "macros",
+  "rt-multi-thread",
+  "sync",
+  "signal",
 ] }
 pin-project-lite = "0.2"
 
 # subxt
 scale-value = "0.18"
-subxt = { version = "0.42.1", features = ["reconnecting-rpc-client"] }
-subxt-rpcs = "0.42.1"
+subxt = { version = "0.43.0", features = ["reconnecting-rpc-client"] }
+subxt-rpcs = "0.43.0"
 
 
 # polkadot-sdk
 polkadot-sdk = { git = "https://github.com/paritytech/polkadot-sdk", features = [
-    "frame-election-provider-support",
-    "frame-support",
-    "sp-npos-elections",
-    "sp-core",
-    "sp-runtime",
-    "sp-version",
-    "pallet-election-provider-multi-block",
+  "frame-election-provider-support",
+  "frame-support",
+  "sp-npos-elections",
+  "sp-core",
+  "sp-runtime",
+  "sp-version",
+  "pallet-election-provider-multi-block",
 ], branch = "master" }
 
 # prometheus
 prometheus = "0.14"
 hyper = { version = "1.6.0", features = ["server", "http1", "http2"] }
 hyper-util = { version = "0.1.15", features = [
-    "server-auto",
-    "server-graceful",
-    "tokio",
+  "server-auto",
+  "server-graceful",
+  "tokio",
 ] }
 http-body-util = "0.1.0"
 once_cell = "1.21"

--- a/src/commands/multi_block/monitor.rs
+++ b/src/commands/multi_block/monitor.rs
@@ -346,7 +346,7 @@ where
 			.storage()
 			.at_latest()
 			.await?
-			.fetch(&runtime::storage().system().account(signer.account_id()))
+			.fetch(&runtime::storage().system().account(signer.account_id().clone()))
 			.await?
 			.ok_or(Error::AccountDoesNotExists)?;
 		prometheus::set_balance(account_info.data.free as f64);
@@ -697,7 +697,7 @@ where
 
 	// Update balance
 	let account_info = storage
-		.fetch(&runtime::storage().system().account(signer.account_id()))
+		.fetch(&runtime::storage().system().account(signer.account_id().clone()))
 		.await?
 		.ok_or(Error::AccountDoesNotExists)?;
 	prometheus::set_balance(account_info.data.free as f64);
@@ -973,7 +973,7 @@ async fn get_submission(
 		.fetch(
 			&runtime::storage()
 				.multi_block_election_signed()
-				.submission_metadata_storage(round, who),
+				.submission_metadata_storage(round, who.clone()),
 		)
 		.await?;
 
@@ -1169,7 +1169,7 @@ where
 			.fetch(
 				&runtime::storage()
 					.multi_block_election_signed()
-					.submission_metadata_storage(old_round, signer.account_id()),
+					.submission_metadata_storage(old_round, signer.account_id().clone()),
 			)
 			.await?;
 

--- a/src/dynamic/multi_block.rs
+++ b/src/dynamic/multi_block.rs
@@ -795,7 +795,7 @@ async fn validate_signed_phase_or_bail(
 					.fetch(
 						&runtime::storage()
 							.multi_block_election_signed()
-							.submission_metadata_storage(round, signer.account_id()),
+							.submission_metadata_storage(round, signer.account_id().clone()),
 					)
 					.await?;
 


### PR DESCRIPTION
Fix breaking changes:

- Add `.clone()` for storage query parameters
- Decode raw bytes manaully when calling `call_raw()` API