### PR TITLE
Fix stalling issue if subscription.next() is stuck

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -306,22 +306,19 @@ mod tests {
 		])
 		.unwrap();
 
-		assert_eq!(
-			opt,
-			Opt {
-				uri: "hi".to_string(),
-				prometheus_port: 9999,
-				log: "info".to_string(),
-				command: Command::Monitor(MultiBlockMonitorConfig {
-					seed_or_path: "//Alice".to_string(),
-					submission_strategy: SubmissionStrategy::IfLeading, // Default
-					do_reduce: true,
-					chunk_size: 0,               // Default
-					min_signed_phase_blocks: 10, // Default
-					shady: false,                // Default
-				}),
-			}
-		);
+		assert_eq!(opt, Opt {
+			uri: "hi".to_string(),
+			prometheus_port: 9999,
+			log: "info".to_string(),
+			command: Command::Monitor(MultiBlockMonitorConfig {
+				seed_or_path: "//Alice".to_string(),
+				submission_strategy: SubmissionStrategy::IfLeading, // Default
+				do_reduce: true,
+				chunk_size: 0,               // Default
+				min_signed_phase_blocks: 10, // Default
+				shady: false,                // Default
+			}),
+		});
 	}
 
 	#[test]


### PR DESCRIPTION
## Changes 

In the listener task:
1. Replaced tokio::select! with tokio::time::timeout that directly wraps subscription.next()
2. Simplified the timeout logic - now it's a straightforward 60-second timeout on each subscription call
3. Fixed the stalling issue - the timeout will always fire after 60 seconds, even if subscription.next() is stuck

The key improvement is that the timeout now wraps the potentially hanging operation directly, providing more reliable detection of a stalled subscription. This should  eliminate the future starvation issue that could prevent the original timeout from firing.

For `runtime_upgrade_task` we follow a different approach. We expect to receive a runtime upgrade very infrequently so a timeout approach doesn't work well. What we do now, is to check periodically every hour if the updater subscription is healthy and if it's not, we recreate it. This way we avoid to recreate it unconditionally, with the unnecessary overhead and with the risk to recreate the connection just while we are actually receiving an update.