### PR TITLE
[DO NOT MERGE] Make janitor transaction submission non-blocking

### DIFF
--- a/src/commands/multi_block/monitor.rs
+++ b/src/commands/multi_block/monitor.rs
@@ -1261,9 +1261,7 @@ async fn clear_old_round_data(
 	let tx_hash = xt.submit().await?;
 	log::debug!(
 		target: LOG_TARGET,
-		"Successfully submitted clear_old_round_data for round {} with tx hash: {:?}",
-		round,
-		tx_hash
+		"Successfully submitted clear_old_round_data for round {round} with tx hash: {tx_hash:?}"
 	);
 	Ok(())
 }


### PR DESCRIPTION
Changed `clear_old_round_data()` to use fire-and-forget transaction submission instead of waiting for finalization. This addresses a correlation between janitor execution and listener task stalls.

Root cause analysis:
- Each task (listener, miner, janitor) gets a cloned Client instance
- However, these clones share the same underlying backend through Arc
- Client contains ChainClient (OnlineClient<PolkadotConfig>)
- OnlineClient stores backend: Arc<dyn Backend<T>>
- Client::new() creates the backend wrapped in Arc::new(backend)
- When Client is cloned, it clones the Arc reference, not the backend

This architecture means all tasks share:
- The same ReconnectingRpcClient
- The same ChainHeadBackend
- The same WebSocket connection

The synchronous wait for transaction finalization was blocking shared resources at the connection/backend level, potentially preventing the listener from receiving new block notifications (this has to be proved though!).

Even forgetting the stalling issue, the fire-and-forget approach is beneficial in any case for the janitor task so this PR still offers the following benefits:
- Removes resource contention between janitor and listener tasks
- Makes janitor task fully non-blocking
- Better overall system responsiveness
- Appropriate for cleanup operations that don't require confirmation

This change works in conjunction with the timeout-based listener implementation introduced by #1119  to reduce / prevent subscription stalls.

NOTE: while the updater task shares the same client/backend with the listener and the janitor, it doesn't appear to have the same blocking behavior that was potentially causing issues with the janitor. The key difference is:
  - Janitor: Was submitting transactions and waiting for finalization (blocking operation)
  - Updater: Only performs read operations and local updates (non-blocking)