### PR TITLE
Fix chain name for Paseo AH

### DIFF
--- a/src/opt.rs
+++ b/src/opt.rs
@@ -47,8 +47,8 @@ impl std::str::FromStr for Chain {
 	fn from_str(s: &str) -> Result<Self, Error> {
 		match s {
 			"polkadot" => Ok(Self::Polkadot),
-			"statemint" => Ok(Self::Polkadot), // Polkadot AH
-			"paseo" => Ok(Self::Polkadot),     // Paseo AH
+			"statemint" => Ok(Self::Polkadot),       // Polkadot AH
+			"asset-hub-paseo" => Ok(Self::Polkadot), // Paseo AH
 			"kusama" => Ok(Self::Kusama),
 			"statemine" => Ok(Self::Kusama), // Kusama AH
 			"westend" => Ok(Self::Westend),


### PR DESCRIPTION
Fix the expect chain name for Paseo AH, otherwise we will get the following error post AHM:

```bash
RUST_LOG="polkadot-staking-miner=trace" ./target/release/polkadot-staking-miner --uri wss://asset-hub-paseo.dotters.network info
2025-08-07T06:27:05.670658Z DEBUG polkadot-staking-miner: attempting to connect to "wss://asset-hub-paseo.dotters.network"    
2025-08-07T06:27:06.168375Z  INFO polkadot-staking-miner: Connected to wss://asset-hub-paseo.dotters.network with ChainHead backend    
Error: InvalidChain("asset-hub-paseo")
```