### PR TITLE
Tentatively fix listener task stalling issue with comprehensive timeout and diagnostics

### DIFF
--- a/src/prometheus.rs
+++ b/src/prometheus.rs
@@ -220,6 +220,46 @@ mod hidden {
 		.unwrap()
 	});
 
+	static STORAGE_QUERY_DURATION: Lazy<Gauge> = Lazy::new(|| {
+		register_gauge!(
+			"staking_miner_storage_query_duration_ms",
+			"Duration of storage queries in milliseconds"
+		)
+		.unwrap()
+	});
+
+	static BLOCK_STATE_DURATION: Lazy<Gauge> = Lazy::new(|| {
+		register_gauge!(
+			"staking_miner_block_state_duration_ms",
+			"Duration of get_block_state() calls in milliseconds"
+		)
+		.unwrap()
+	});
+
+	static BLOCK_DETAILS_DURATION: Lazy<Gauge> = Lazy::new(|| {
+		register_gauge!(
+			"staking_miner_block_details_duration_ms",
+			"Duration of BlockDetails::new() calls in milliseconds"
+		)
+		.unwrap()
+	});
+
+	static LAST_BLOCK_PROCESSING_TIME: Lazy<Gauge> = Lazy::new(|| {
+		register_gauge!(opts!(
+			"staking_miner_last_block_processing_timestamp",
+			"Unix timestamp of when the last block was successfully processed by listener"
+		))
+		.unwrap()
+	});
+
+	static BLOCK_PROCESSING_STALLS: Lazy<Counter> = Lazy::new(|| {
+		register_counter!(opts!(
+			"staking_miner_block_processing_stalls_total",
+			"Total number of times block processing was detected as stalled (different from subscription stalls)"
+		))
+		.unwrap()
+	});
+
 	pub fn on_runtime_upgrade() {
 		RUNTIME_UPGRADES.inc();
 	}
@@ -273,5 +313,28 @@ mod hidden {
 
 	pub fn on_updater_subscription_stall() {
 		UPDATER_SUBSCRIPTION_STALLS.inc();
+	}
+
+	pub fn observe_storage_query_duration(duration_ms: f64) {
+		STORAGE_QUERY_DURATION.set(duration_ms);
+	}
+
+	pub fn observe_block_state_duration(duration_ms: f64) {
+		BLOCK_STATE_DURATION.set(duration_ms);
+	}
+
+	pub fn observe_block_details_duration(duration_ms: f64) {
+		BLOCK_DETAILS_DURATION.set(duration_ms);
+	}
+
+	pub fn set_last_block_processing_time() {
+		use std::time::{SystemTime, UNIX_EPOCH};
+		let timestamp =
+			SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs() as f64;
+		LAST_BLOCK_PROCESSING_TIME.set(timestamp);
+	}
+
+	pub fn on_block_processing_stall() {
+		BLOCK_PROCESSING_STALLS.inc();
 	}
 }


### PR DESCRIPTION
## Problem

The listener task occasionally stalls after janitor cleanup operations, despite PR #1119's subscription timeout improvements. Critical observation: the runtime updater task continues receiving updates while sharing the same ChainClient and ChainHeadBackend, proving the underlying subscription infrastructure is presumably healthy.
This seems to suggest that the hang occurs in listener's internal processing, not in the subscription itself.

## Root Cause Analysis

- Since updater task works, we assume subscription.next() is NOT blocking
- The hang then must occur AFTER subscription.next() returns successfully
- Current timeout only wraps subscription.next(), missing internal processing hangs
- Janitor's synchronous submit_and_watch() + wait_tx_in_finalized_block() shouldn't create transient resource contention affecting listener's storage queries but for a cleanup task, the `submit` only approach is better.

## Solution

1. Comprehensive timeout protection:
   - Wrap entire block processing logic (not just subscription.next())
   - Add 90s timeout for all post-subscription processing
   - Detect "zombie" processing where subscription works but processing hangs

2. Enhanced diagnostics:
   - Add detailed trace logging throughout processing pipeline. Extra logging is very verbose with `trace` level
   - Track storage query durations with prometheus metrics
   - Separate subscription health from block processing health metrics
   - Monitor exact hang points (storage queries, phase checks, BlockDetails)

3. Improve janitor task:
   - Change clear_old_round_data() from submit_and_watch() to submit() and remove wait_tx_in_finalized_block() to avoid blocking

## New Metrics

- staking_miner_storage_query_duration_ms
- staking_miner_block_state_duration_ms
- staking_miner_block_details_duration_ms
- staking_miner_block_processing_stalls_total
- staking_miner_last_block_processing_timestamp

Most if not all of these metrics can be removed once we have successfully verified the fix or better tracked the stalling issue.

I would then sync with devops to add new alarms related to the stalling [here](https://github.com/paritytech/devops-cloud-infra/blob/main/kubernetes/kube-prometheus-stack/files/parity-substrate-apps.rules#L1-L26) so that we can be immediately notified about it when it happens.

## Conclusion

This fix aims to address what we suspect to be the actual problem (internal processing hangs) rather than the subscription stalls, based on the key evidence that the updater task continues working normally.