### PR TITLE
Improve stalling issues with comprehensive timeout handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,9 @@ staking_miner_block_processing_stalls_total 2
 # HELP staking_miner_tx_finalization_timeouts_total Total number of transaction finalization timeouts
 # TYPE staking_miner_tx_finalization_timeouts_total counter
 staking_miner_tx_finalization_timeouts_total 0
+# HELP staking_miner_mining_timeouts_total Total number of solution mining timeouts
+# TYPE staking_miner_mining_timeouts_total counter
+staking_miner_mining_timeouts_total 0
 ```
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -285,6 +285,12 @@ staking_miner_listener_subscription_stalls_total 1
 # HELP staking_miner_updater_subscription_stalls_total Total number of times the updater subscription was detected as stalled and recreated
 # TYPE staking_miner_updater_subscription_stalls_total counter
 staking_miner_updater_subscription_stalls_total 0
+# HELP staking_miner_block_processing_stalls_total Total number of times block processing was detected as stalled
+# TYPE staking_miner_block_processing_stalls_total counter
+staking_miner_block_processing_stalls_total 2
+# HELP staking_miner_tx_finalization_timeouts_total Total number of transaction finalization timeouts
+# TYPE staking_miner_tx_finalization_timeouts_total counter
+staking_miner_tx_finalization_timeouts_total 0
 ```
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ next era and how stake is distributed among them to maximize security and decent
 The nomination process in a nutshell:
 
 ```text
- Nominators → Stake DOT → Nominate Validators → Validator Set Selection
+Nominators → Stake DOT → Nominate Validators → Validator Set Selection
 ```
 
 where
@@ -294,6 +294,23 @@ staking_miner_tx_finalization_timeouts_total 0
 # HELP staking_miner_mining_timeouts_total Total number of solution mining timeouts
 # TYPE staking_miner_mining_timeouts_total counter
 staking_miner_mining_timeouts_total 0
+# HELP staking_miner_check_existing_submission_timeouts_total Total number of check existing submission timeouts
+# TYPE staking_miner_check_existing_submission_timeouts_total counter
+staking_miner_check_existing_submission_timeouts_total 0
+# HELP staking_miner_bail_timeouts_total Total number of bail operation timeouts
+# TYPE staking_miner_bail_timeouts_total counter
+staking_miner_bail_timeouts_total 0
+# HELP staking_miner_submit_timeouts_total Total number of solution submission timeouts
+# TYPE staking_miner_submit_timeouts_total counter
+staking_miner_submit_timeouts_total 0
+
+# Performance Duration Metrics (for successful operations)
+# HELP staking_miner_check_existing_submission_duration_ms Duration of checking existing submissions in milliseconds
+# TYPE staking_miner_check_existing_submission_duration_ms gauge
+staking_miner_check_existing_submission_duration_ms 125
+# HELP staking_miner_bail_duration_ms Duration of bail operations in milliseconds
+# TYPE staking_miner_bail_duration_ms gauge
+staking_miner_bail_duration_ms 2340
 ```
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -300,6 +300,15 @@ staking_miner_bail_timeouts_total 0
 # HELP staking_miner_submit_timeouts_total Total number of solution submission timeouts
 # TYPE staking_miner_submit_timeouts_total counter
 staking_miner_submit_timeouts_total 0
+# HELP staking_miner_phase_check_timeouts_total Total number of phase check timeouts
+# TYPE staking_miner_phase_check_timeouts_total counter
+staking_miner_phase_check_timeouts_total 0
+# HELP staking_miner_score_check_timeouts_total Total number of score check timeouts
+# TYPE staking_miner_score_check_timeouts_total counter
+staking_miner_score_check_timeouts_total 0
+# HELP staking_miner_missing_pages_timeouts_total Total number of missing pages submission timeouts
+# TYPE staking_miner_missing_pages_timeouts_total counter
+staking_miner_missing_pages_timeouts_total 0
 
 # Performance Duration Metrics (for successful operations)
 # HELP staking_miner_check_existing_submission_duration_ms Duration of checking existing submissions in milliseconds
@@ -308,6 +317,15 @@ staking_miner_check_existing_submission_duration_ms 125
 # HELP staking_miner_bail_duration_ms Duration of bail operations in milliseconds
 # TYPE staking_miner_bail_duration_ms gauge
 staking_miner_bail_duration_ms 2340
+# HELP staking_miner_phase_check_duration_ms Duration of phase check operations in milliseconds
+# TYPE staking_miner_phase_check_duration_ms gauge
+staking_miner_phase_check_duration_ms 85
+# HELP staking_miner_score_check_duration_ms Duration of score check operations in milliseconds
+# TYPE staking_miner_score_check_duration_ms gauge
+staking_miner_score_check_duration_ms 120
+# HELP staking_miner_missing_pages_duration_ms Duration of missing pages submission in milliseconds
+# TYPE staking_miner_missing_pages_duration_ms gauge
+staking_miner_missing_pages_duration_ms 8500
 ```
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -288,9 +288,6 @@ staking_miner_updater_subscription_stalls_total 0
 # HELP staking_miner_block_processing_stalls_total Total number of times block processing was detected as stalled
 # TYPE staking_miner_block_processing_stalls_total counter
 staking_miner_block_processing_stalls_total 2
-# HELP staking_miner_tx_finalization_timeouts_total Total number of transaction finalization timeouts
-# TYPE staking_miner_tx_finalization_timeouts_total counter
-staking_miner_tx_finalization_timeouts_total 0
 # HELP staking_miner_mining_timeouts_total Total number of solution mining timeouts
 # TYPE staking_miner_mining_timeouts_total counter
 staking_miner_mining_timeouts_total 0

--- a/src/commands/multi_block/monitor.rs
+++ b/src/commands/multi_block/monitor.rs
@@ -114,6 +114,9 @@ where
 		},
 		_ => {
 			log::trace!(target: LOG_TARGET, "Block #{block_number}, Phase {phase:?} - nothing to do");
+			// Update timestamp of successful listener's block processing
+			prometheus::set_last_block_processing_time();
+
 			return Ok(ListenerAction::Continue);
 		},
 	}
@@ -131,7 +134,7 @@ where
 	match miner_tx.try_send(message) {
 		Ok(()) => {
 			log::trace!(target: LOG_TARGET, "Sent block #{block_number} to miner");
-			// Update timestamp of successful block processing
+			// Update timestamp of successful listener's block processing
 			prometheus::set_last_block_processing_time();
 			// Don't wait for response to allow proper backpressure - listener must continue
 			// processing blocks

--- a/src/commands/multi_block/monitor.rs
+++ b/src/commands/multi_block/monitor.rs
@@ -1177,7 +1177,7 @@ async fn execute_shady_behavior(
 	};
 
 	// Wait for the malicious score registration to be included
-	let tx = utils::wait_tx_in_finalized_block(tx_status).await?;
+	let tx = utils::wait_tx_in_finalized_block(tx_status, "registering malicious score").await?;
 	let events = tx.wait_for_success().await?;
 	if !events.has::<runtime::multi_block_election_signed::events::Registered>()? {
 		return Err(Error::MissingTxEvent("Register malicious score".to_string()));
@@ -1370,7 +1370,8 @@ fn is_critical_miner_error(error: &Error) -> bool {
 		Error::FailedToSubmitPages(_) |
 		Error::SolutionValidation { .. } |
 		Error::WrongPageCount { .. } |
-		Error::WrongRound { .. } => false,
+		Error::WrongRound { .. } |
+		Error::TxFinalizationTimeout { .. } => false,
 		Error::Subxt(boxed_err) if matches!(boxed_err.as_ref(), subxt::Error::Runtime(_)) => false, /* e.g. Subxt(Runtime(Module(ModuleError(<MultiBlockElectionSigned::Duplicate>)))) */
 		Error::Subxt(boxed_err) if matches!(boxed_err.as_ref(), subxt::Error::Transaction(_)) =>
 			false, /* e.g. Subxt(Transaction(Invalid("Transaction is invalid (eg because of a bad */

--- a/src/commands/multi_block/monitor.rs
+++ b/src/commands/multi_block/monitor.rs
@@ -1202,7 +1202,7 @@ async fn execute_shady_behavior(
 	};
 
 	// Wait for the malicious score registration to be included
-	let tx = utils::wait_tx_in_finalized_block(tx_status, "registering malicious score").await?;
+	let tx = utils::wait_tx_in_finalized_block(tx_status).await?;
 	let events = tx.wait_for_success().await?;
 	if !events.has::<runtime::multi_block_election_signed::events::Registered>()? {
 		return Err(Error::MissingTxEvent("Register malicious score".to_string()));
@@ -1396,7 +1396,6 @@ fn is_critical_miner_error(error: &Error) -> bool {
 		Error::SolutionValidation { .. } |
 		Error::WrongPageCount { .. } |
 		Error::WrongRound { .. } |
-		Error::TxFinalizationTimeout { .. } |
 		Error::MiningTimeout { .. } |
 		Error::CheckExistingSubmissionTimeout { .. } |
 		Error::BailTimeout { .. } |

--- a/src/commands/multi_block/monitor.rs
+++ b/src/commands/multi_block/monitor.rs
@@ -949,7 +949,7 @@ where
 	{
 		Ok(result) => result?,
 		Err(_) => {
-			log::error!(target: LOG_TARGET, "Check existing submission timed out after {} seconds for block #{}", CHECK_EXISTING_SUBMISSION_TIMEOUT_SECS, block_number);
+			log::error!(target: LOG_TARGET, "Check existing submission timed out after {CHECK_EXISTING_SUBMISSION_TIMEOUT_SECS} seconds for block #{block_number}");
 			prometheus::on_check_existing_submission_timeout();
 			return Err(Error::CheckExistingSubmissionTimeout {
 				timeout_secs: CHECK_EXISTING_SUBMISSION_TIMEOUT_SECS,

--- a/src/dynamic/multi_block.rs
+++ b/src/dynamic/multi_block.rs
@@ -189,46 +189,61 @@ where
 	T::VoterSnapshotPerBlock: Send,
 	T::MaxVotesPerVoter: Send,
 {
-	log::trace!(
-		target: LOG_TARGET,
-		"Mine_and_submit: election target snap size: {:?}, voter snap size: {:?}",
-		target_snapshot.len(),
-		voter_snapshot_paged.len()
-	);
+	const MINING_TIMEOUT_SECS: u64 = 600; // 10 minutes
 
-	let voter_pages: BoundedVec<VoterSnapshotPageOf<T>, T::Pages> =
-		BoundedVec::truncate_from(voter_snapshot_paged);
+	let mining_task = async {
+		log::trace!(
+			target: LOG_TARGET,
+			"Mine_and_submit: election target snap size: {:?}, voter snap size: {:?}",
+			target_snapshot.len(),
+			voter_snapshot_paged.len()
+		);
 
-	log::trace!(
-		target: LOG_TARGET,
-		"MineInput: desired_targets={desired_targets},pages={n_pages},target_snapshot_len={},voters_pages_len={},do_reduce={do_reduce},round={round},at={block_number}",
-		target_snapshot.len(), voter_pages.len()
-	);
+		let voter_pages: BoundedVec<VoterSnapshotPageOf<T>, T::Pages> =
+			BoundedVec::truncate_from(voter_snapshot_paged);
 
-	let input = MineInput {
-		desired_targets,
-		all_targets: target_snapshot.clone(),
-		voter_pages: voter_pages.clone(),
-		pages: n_pages,
-		do_reduce,
-		round,
+		log::trace!(
+			target: LOG_TARGET,
+			"MineInput: desired_targets={desired_targets},pages={n_pages},target_snapshot_len={},voters_pages_len={},do_reduce={do_reduce},round={round},at={block_number}",
+			target_snapshot.len(), voter_pages.len()
+		);
+
+		let input = MineInput {
+			desired_targets,
+			all_targets: target_snapshot.clone(),
+			voter_pages: voter_pages.clone(),
+			pages: n_pages,
+			do_reduce,
+			round,
+		};
+
+		// Mine solution
+		tokio::task::spawn_blocking(move || {
+			let paged_raw_solution =
+				Miner::<T>::mine_solution(input).map_err(|e| Error::Other(format!("{e:?}")))?;
+			Miner::<T>::check_feasibility(
+				&paged_raw_solution,
+				&voter_pages,
+				&target_snapshot,
+				desired_targets,
+			)
+			.map_err(|e| Error::Feasibility(format!("{e:?}")))?;
+			Ok(paged_raw_solution)
+		})
+		.await
+		.map_err(|e| Error::Other(format!("{e:?}")))?
 	};
 
-	// Mine solution
-	tokio::task::spawn_blocking(move || {
-		let paged_raw_solution =
-			Miner::<T>::mine_solution(input).map_err(|e| Error::Other(format!("{e:?}")))?;
-		Miner::<T>::check_feasibility(
-			&paged_raw_solution,
-			&voter_pages,
-			&target_snapshot,
-			desired_targets,
-		)
-		.map_err(|e| Error::Feasibility(format!("{e:?}")))?;
-		Ok(paged_raw_solution)
-	})
-	.await
-	.map_err(|e| Error::Other(format!("{e:?}")))?
+	match tokio::time::timeout(std::time::Duration::from_secs(MINING_TIMEOUT_SECS), mining_task)
+		.await
+	{
+		Ok(result) => result,
+		Err(_) => {
+			log::error!(target: LOG_TARGET, "Mining solution timed out after {} seconds for block #{}", MINING_TIMEOUT_SECS, block_number);
+			crate::prometheus::on_mining_timeout();
+			Err(Error::MiningTimeout { timeout_secs: MINING_TIMEOUT_SECS })
+		},
+	}
 }
 
 /// Fetches the target snapshot and all voter snapshots which are missing
@@ -331,7 +346,7 @@ pub(crate) async fn check_and_update_target_snapshot<T: MinerConfig>(
 /// Submit a multi-block solution.
 ///
 /// It registers the score and submits all solution pages.
-pub(crate) async fn submit<T: MinerConfig + Send + Sync + 'static>(
+async fn submit_impl<T: MinerConfig + Send + Sync + 'static>(
 	client: &Client,
 	signer: &Signer,
 	mut paged_raw_solution: PagedRawSolution<T>,
@@ -508,6 +523,32 @@ pub(crate) async fn submit<T: MinerConfig + Send + Sync + 'static>(
 		.await?;
 
 		Err(Error::FailedToSubmitPages(failed_pages.len()))
+	}
+}
+
+/// Submit a multi-block solution with timeout and metrics.
+pub(crate) async fn submit<T: MinerConfig + Send + Sync + 'static>(
+	client: &Client,
+	signer: &Signer,
+	paged_raw_solution: PagedRawSolution<T>,
+	chunk_size: usize,
+	round: u32,
+	min_signed_phase_blocks: u32,
+) -> Result<(), Error> {
+	const SUBMIT_TIMEOUT_SECS: u64 = 1800; // 30 minutes
+
+	match tokio::time::timeout(
+		std::time::Duration::from_secs(SUBMIT_TIMEOUT_SECS),
+		submit_impl(client, signer, paged_raw_solution, chunk_size, round, min_signed_phase_blocks),
+	)
+	.await
+	{
+		Ok(result) => result,
+		Err(_) => {
+			log::error!(target: LOG_TARGET, "Submit operation timed out after {} seconds", SUBMIT_TIMEOUT_SECS);
+			crate::prometheus::on_submit_timeout();
+			Err(Error::SubmitTimeout { timeout_secs: SUBMIT_TIMEOUT_SECS })
+		},
 	}
 }
 
@@ -744,13 +785,31 @@ pub(crate) async fn inner_submit_pages_chunked<T: MinerConfig + 'static>(
 
 /// Submit a bail transaction to revert incomplete submissions
 pub(crate) async fn bail(client: &Client, signer: &Signer) -> Result<(), Error> {
-	let bail_tx = runtime::tx().multi_block_election_signed().bail();
-	let nonce = client.chain_api().tx().account_nonce(signer.account_id()).await?;
-	let xt_cfg = ExtrinsicParamsBuilder::default().nonce(nonce).build();
-	let xt = client.chain_api().tx().create_signed(&bail_tx, &**signer, xt_cfg).await?;
-	let tx = xt.submit_and_watch().await?;
-	utils::wait_tx_in_finalized_block(tx, "bailing").await?;
-	Ok(())
+	const BAIL_TIMEOUT_SECS: u64 = 120; // 2 minutes
+
+	let bail_task = async {
+		let start_time = std::time::Instant::now();
+
+		let bail_tx = runtime::tx().multi_block_election_signed().bail();
+		let nonce = client.chain_api().tx().account_nonce(signer.account_id()).await?;
+		let xt_cfg = ExtrinsicParamsBuilder::default().nonce(nonce).build();
+		let xt = client.chain_api().tx().create_signed(&bail_tx, &**signer, xt_cfg).await?;
+		let tx = xt.submit_and_watch().await?;
+		utils::wait_tx_in_finalized_block(tx, "bailing").await?;
+
+		let duration = start_time.elapsed();
+		crate::prometheus::observe_bail_duration(duration.as_millis() as f64);
+		Ok::<_, Error>(())
+	};
+
+	match tokio::time::timeout(std::time::Duration::from_secs(BAIL_TIMEOUT_SECS), bail_task).await {
+		Ok(result) => result,
+		Err(_) => {
+			log::error!(target: LOG_TARGET, "Bail operation timed out after {} seconds", BAIL_TIMEOUT_SECS);
+			crate::prometheus::on_bail_timeout();
+			Err(Error::BailTimeout { timeout_secs: BAIL_TIMEOUT_SECS })
+		},
+	}
 }
 
 /// Get the blocks remaining from a SignedPhase.

--- a/src/dynamic/multi_block.rs
+++ b/src/dynamic/multi_block.rs
@@ -239,7 +239,7 @@ where
 	{
 		Ok(result) => result,
 		Err(_) => {
-			log::error!(target: LOG_TARGET, "Mining solution timed out after {} seconds for block #{}", MINING_TIMEOUT_SECS, block_number);
+			log::error!(target: LOG_TARGET, "Mining solution timed out after {MINING_TIMEOUT_SECS} seconds for block #{block_number}");
 			crate::prometheus::on_mining_timeout();
 			Err(Error::MiningTimeout { timeout_secs: MINING_TIMEOUT_SECS })
 		},
@@ -545,7 +545,7 @@ pub(crate) async fn submit<T: MinerConfig + Send + Sync + 'static>(
 	{
 		Ok(result) => result,
 		Err(_) => {
-			log::error!(target: LOG_TARGET, "Submit operation timed out after {} seconds", SUBMIT_TIMEOUT_SECS);
+			log::error!(target: LOG_TARGET, "Submit operation timed out after {SUBMIT_TIMEOUT_SECS} seconds");
 			crate::prometheus::on_submit_timeout();
 			Err(Error::SubmitTimeout { timeout_secs: SUBMIT_TIMEOUT_SECS })
 		},
@@ -803,7 +803,7 @@ pub(crate) async fn bail(client: &Client, signer: &Signer) -> Result<(), Error> 
 	match tokio::time::timeout(std::time::Duration::from_secs(BAIL_TIMEOUT_SECS), bail_task).await {
 		Ok(result) => result,
 		Err(_) => {
-			log::error!(target: LOG_TARGET, "Bail operation timed out after {} seconds", BAIL_TIMEOUT_SECS);
+			log::error!(target: LOG_TARGET, "Bail operation timed out after {BAIL_TIMEOUT_SECS} seconds");
 			crate::prometheus::on_bail_timeout();
 			Err(Error::BailTimeout { timeout_secs: BAIL_TIMEOUT_SECS })
 		},

--- a/src/dynamic/multi_block.rs
+++ b/src/dynamic/multi_block.rs
@@ -396,7 +396,7 @@ async fn submit_impl<T: MinerConfig + Send + Sync + 'static>(
 		}
 	};
 
-	// 1. Wait for the `register_score tx` to be included in a block.
+	// 2. Wait for the `register_score tx` to be included in a block.
 	//
 	// NOTE: It's slow to iterate over the events to check if the score was registered
 	// but it's performed for registering the score only once.
@@ -408,7 +408,7 @@ async fn submit_impl<T: MinerConfig + Send + Sync + 'static>(
 
 	log::info!(target: LOG_TARGET, "Score registered at block {:?}", tx.block_hash());
 
-	// 2. Get current phase and validate before submitting pages
+	// 3. Get current phase and validate before submitting pages
 	let storage = utils::storage_at_head(client).await?;
 	let current_phase = storage
 		.fetch_or_default(&runtime::storage().multi_block_election().current_phase())
@@ -424,7 +424,7 @@ async fn submit_impl<T: MinerConfig + Send + Sync + 'static>(
 		.map(|(page, solution)| (page as u32, solution.clone()))
 		.collect::<Vec<_>>();
 
-	// 3. Submit all solution pages using the appropriate strategy based on chunk_size
+	// 4. Submit all solution pages using the appropriate strategy based on chunk_size
 	let failed_pages = if chunk_size == 0 {
 		inner_submit_pages_concurrent::<T>(
 			client,
@@ -446,7 +446,7 @@ async fn submit_impl<T: MinerConfig + Send + Sync + 'static>(
 		.await?
 	};
 
-	// 4. All pages were submitted successfully, we are done.
+	// 5. All pages were submitted successfully, we are done.
 	if failed_pages.is_empty() {
 		// Record successful submission
 		crate::prometheus::on_submission_success();
@@ -459,7 +459,7 @@ async fn submit_impl<T: MinerConfig + Send + Sync + 'static>(
 		failed_pages.len()
 	);
 
-	// 5. Get current phase and validate before retrying failed pages
+	// 6. Get current phase and validate before retrying failed pages
 	let storage = utils::storage_at_head(client).await?;
 	let current_phase = storage
 		.fetch_or_default(&runtime::storage().multi_block_election().current_phase())
@@ -468,7 +468,7 @@ async fn submit_impl<T: MinerConfig + Send + Sync + 'static>(
 	validate_signed_phase_or_bail(&current_phase, client, signer, round, min_signed_phase_blocks)
 		.await?;
 
-	// 6. Retry failed pages, one time.
+	// 7. Retry failed pages, one time.
 	let mut solutions = Vec::new();
 	for page in failed_pages {
 		let solution = std::mem::take(&mut paged_raw_solution.solution_pages[page as usize]);

--- a/src/dynamic/multi_block.rs
+++ b/src/dynamic/multi_block.rs
@@ -385,7 +385,7 @@ pub(crate) async fn submit<T: MinerConfig + Send + Sync + 'static>(
 	//
 	// NOTE: It's slow to iterate over the events to check if the score was registered
 	// but it's performed for registering the score only once.
-	let tx = utils::wait_tx_in_finalized_block(tx_status).await?;
+	let tx = utils::wait_tx_in_finalized_block(tx_status, "registering score").await?;
 	let events = tx.wait_for_success().await?;
 	if !events.has::<runtime::multi_block_election_signed::events::Registered>()? {
 		return Err(Error::MissingTxEvent("Register score".to_string()));
@@ -568,7 +568,9 @@ async fn submit_pages_batch<T: MinerConfig + 'static>(
 		.await?;
 
 		txs.push(async move {
-			match utils::wait_tx_in_finalized_block(tx_status).await {
+			match utils::wait_tx_in_finalized_block(tx_status, &format!("submitting page {}", page))
+				.await
+			{
 				Ok(tx) => Ok(tx),
 				Err(_) => Err(page),
 			}
@@ -747,7 +749,7 @@ pub(crate) async fn bail(client: &Client, signer: &Signer) -> Result<(), Error> 
 	let xt_cfg = ExtrinsicParamsBuilder::default().nonce(nonce).build();
 	let xt = client.chain_api().tx().create_signed(&bail_tx, &**signer, xt_cfg).await?;
 	let tx = xt.submit_and_watch().await?;
-	utils::wait_tx_in_finalized_block(tx).await?;
+	utils::wait_tx_in_finalized_block(tx, "bailing").await?;
 	Ok(())
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -73,6 +73,12 @@ pub enum Error {
 	TxFinalizationTimeout { operation: String, timeout_secs: u64 },
 	#[error("Solution mining timed out after {timeout_secs} seconds")]
 	MiningTimeout { timeout_secs: u64 },
+	#[error("Checking existing submission timed out after {timeout_secs} seconds")]
+	CheckExistingSubmissionTimeout { timeout_secs: u64 },
+	#[error("Bail operation timed out after {timeout_secs} seconds")]
+	BailTimeout { timeout_secs: u64 },
+	#[error("Solution submission timed out after {timeout_secs} seconds")]
+	SubmitTimeout { timeout_secs: u64 },
 }
 
 impl From<subxt_rpcs::Error> for Error {

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,6 +15,24 @@
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
 #[derive(thiserror::Error, Debug)]
+pub enum TimeoutError {
+	#[error("Solution mining timed out after {timeout_secs} seconds")]
+	Mining { timeout_secs: u64 },
+	#[error("Checking existing submission timed out after {timeout_secs} seconds")]
+	CheckExistingSubmission { timeout_secs: u64 },
+	#[error("Bail operation timed out after {timeout_secs} seconds")]
+	Bail { timeout_secs: u64 },
+	#[error("Solution submission timed out after {timeout_secs} seconds")]
+	Submit { timeout_secs: u64 },
+	#[error("Phase check timed out after {timeout_secs} seconds")]
+	PhaseCheck { timeout_secs: u64 },
+	#[error("Score check timed out after {timeout_secs} seconds")]
+	ScoreCheck { timeout_secs: u64 },
+	#[error("Missing pages submission timed out after {timeout_secs} seconds")]
+	MissingPages { timeout_secs: u64 },
+}
+
+#[derive(thiserror::Error, Debug)]
 pub enum Error {
 	#[error("Failed to parse log directive: `{0}´")]
 	LogParse(#[from] tracing_subscriber::filter::ParseError),
@@ -67,20 +85,8 @@ pub enum Error {
 		"Wrong round: solution is for round {solution_round} but current round is {current_round}"
 	)]
 	WrongRound { solution_round: u32, current_round: u32 },
-	#[error("Solution mining timed out after {timeout_secs} seconds")]
-	MiningTimeout { timeout_secs: u64 },
-	#[error("Checking existing submission timed out after {timeout_secs} seconds")]
-	CheckExistingSubmissionTimeout { timeout_secs: u64 },
-	#[error("Bail operation timed out after {timeout_secs} seconds")]
-	BailTimeout { timeout_secs: u64 },
-	#[error("Solution submission timed out after {timeout_secs} seconds")]
-	SubmitTimeout { timeout_secs: u64 },
-	#[error("Phase check timed out after {timeout_secs} seconds")]
-	PhaseCheckTimeout { timeout_secs: u64 },
-	#[error("Score check timed out after {timeout_secs} seconds")]
-	ScoreCheckTimeout { timeout_secs: u64 },
-	#[error("Missing pages submission timed out after {timeout_secs} seconds")]
-	MissingPagesTimeout { timeout_secs: u64 },
+	#[error("Operation timed out: {0}")]
+	Timeout(#[from] TimeoutError),
 }
 
 impl From<subxt_rpcs::Error> for Error {

--- a/src/error.rs
+++ b/src/error.rs
@@ -67,10 +67,6 @@ pub enum Error {
 		"Wrong round: solution is for round {solution_round} but current round is {current_round}"
 	)]
 	WrongRound { solution_round: u32, current_round: u32 },
-	#[error(
-		"Transaction finalization timed out after {timeout_secs} seconds for operation: {operation}"
-	)]
-	TxFinalizationTimeout { operation: String, timeout_secs: u64 },
 	#[error("Solution mining timed out after {timeout_secs} seconds")]
 	MiningTimeout { timeout_secs: u64 },
 	#[error("Checking existing submission timed out after {timeout_secs} seconds")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -71,6 +71,8 @@ pub enum Error {
 		"Transaction finalization timed out after {timeout_secs} seconds for operation: {operation}"
 	)]
 	TxFinalizationTimeout { operation: String, timeout_secs: u64 },
+	#[error("Solution mining timed out after {timeout_secs} seconds")]
+	MiningTimeout { timeout_secs: u64 },
 }
 
 impl From<subxt_rpcs::Error> for Error {

--- a/src/error.rs
+++ b/src/error.rs
@@ -75,6 +75,12 @@ pub enum Error {
 	BailTimeout { timeout_secs: u64 },
 	#[error("Solution submission timed out after {timeout_secs} seconds")]
 	SubmitTimeout { timeout_secs: u64 },
+	#[error("Phase check timed out after {timeout_secs} seconds")]
+	PhaseCheckTimeout { timeout_secs: u64 },
+	#[error("Score check timed out after {timeout_secs} seconds")]
+	ScoreCheckTimeout { timeout_secs: u64 },
+	#[error("Missing pages submission timed out after {timeout_secs} seconds")]
+	MissingPagesTimeout { timeout_secs: u64 },
 }
 
 impl From<subxt_rpcs::Error> for Error {

--- a/src/error.rs
+++ b/src/error.rs
@@ -67,6 +67,10 @@ pub enum Error {
 		"Wrong round: solution is for round {solution_round} but current round is {current_round}"
 	)]
 	WrongRound { solution_round: u32, current_round: u32 },
+	#[error(
+		"Transaction finalization timed out after {timeout_secs} seconds for operation: {operation}"
+	)]
+	TxFinalizationTimeout { operation: String, timeout_secs: u64 },
 }
 
 impl From<subxt_rpcs::Error> for Error {

--- a/src/prometheus.rs
+++ b/src/prometheus.rs
@@ -243,6 +243,20 @@ mod hidden {
 		)
 		.unwrap()
 	});
+	static CHECK_EXISTING_SUBMISSION_DURATION: Lazy<Gauge> = Lazy::new(|| {
+		register_gauge!(
+			"staking_miner_check_existing_submission_duration_ms",
+			"Duration of checking and handling existing submissions in milliseconds"
+		)
+		.unwrap()
+	});
+	static BAIL_DURATION: Lazy<Gauge> = Lazy::new(|| {
+		register_gauge!(
+			"staking_miner_bail_duration_ms",
+			"Duration of bail operations in milliseconds"
+		)
+		.unwrap()
+	});
 
 	static LAST_BLOCK_PROCESSING_TIME: Lazy<Gauge> = Lazy::new(|| {
 		register_gauge!(opts!(
@@ -270,6 +284,27 @@ mod hidden {
 		register_counter!(opts!(
 			"staking_miner_mining_timeouts_total",
 			"Total number of solution mining timeouts"
+		))
+		.unwrap()
+	});
+	static CHECK_EXISTING_SUBMISSION_TIMEOUTS: Lazy<Counter> = Lazy::new(|| {
+		register_counter!(opts!(
+			"staking_miner_check_existing_submission_timeouts_total",
+			"Total number of check existing submission timeouts"
+		))
+		.unwrap()
+	});
+	static BAIL_TIMEOUTS: Lazy<Counter> = Lazy::new(|| {
+		register_counter!(opts!(
+			"staking_miner_bail_timeouts_total",
+			"Total number of bail operation timeouts"
+		))
+		.unwrap()
+	});
+	static SUBMIT_TIMEOUTS: Lazy<Counter> = Lazy::new(|| {
+		register_counter!(opts!(
+			"staking_miner_submit_timeouts_total",
+			"Total number of solution submission timeouts"
 		))
 		.unwrap()
 	});
@@ -340,6 +375,12 @@ mod hidden {
 	pub fn observe_block_details_duration(duration_ms: f64) {
 		BLOCK_DETAILS_DURATION.set(duration_ms);
 	}
+	pub fn observe_check_existing_submission_duration(duration_ms: f64) {
+		CHECK_EXISTING_SUBMISSION_DURATION.set(duration_ms);
+	}
+	pub fn observe_bail_duration(duration_ms: f64) {
+		BAIL_DURATION.set(duration_ms);
+	}
 
 	pub fn set_last_block_processing_time() {
 		use std::time::{SystemTime, UNIX_EPOCH};
@@ -356,5 +397,14 @@ mod hidden {
 	}
 	pub fn on_mining_timeout() {
 		MINING_TIMEOUTS.inc();
+	}
+	pub fn on_check_existing_submission_timeout() {
+		CHECK_EXISTING_SUBMISSION_TIMEOUTS.inc();
+	}
+	pub fn on_bail_timeout() {
+		BAIL_TIMEOUTS.inc();
+	}
+	pub fn on_submit_timeout() {
+		SUBMIT_TIMEOUTS.inc();
 	}
 }

--- a/src/prometheus.rs
+++ b/src/prometheus.rs
@@ -257,6 +257,34 @@ mod hidden {
 		)
 		.unwrap()
 	});
+	static BALANCE_FETCH_DURATION: Lazy<Gauge> = Lazy::new(|| {
+		register_gauge!(
+			"staking_miner_balance_fetch_duration_ms",
+			"Duration of balance fetch operations in milliseconds"
+		)
+		.unwrap()
+	});
+	static PHASE_CHECK_DURATION: Lazy<Gauge> = Lazy::new(|| {
+		register_gauge!(
+			"staking_miner_phase_check_duration_ms",
+			"Duration of phase check operations in milliseconds"
+		)
+		.unwrap()
+	});
+	static SCORE_CHECK_DURATION: Lazy<Gauge> = Lazy::new(|| {
+		register_gauge!(
+			"staking_miner_score_check_duration_ms",
+			"Duration of score check operations in milliseconds"
+		)
+		.unwrap()
+	});
+	static MISSING_PAGES_DURATION: Lazy<Gauge> = Lazy::new(|| {
+		register_gauge!(
+			"staking_miner_missing_pages_duration_ms",
+			"Duration of missing pages submission in milliseconds"
+		)
+		.unwrap()
+	});
 
 	static LAST_BLOCK_PROCESSING_TIME: Lazy<Gauge> = Lazy::new(|| {
 		register_gauge!(opts!(
@@ -298,6 +326,34 @@ mod hidden {
 		register_counter!(opts!(
 			"staking_miner_submit_timeouts_total",
 			"Total number of solution submission timeouts"
+		))
+		.unwrap()
+	});
+	static BALANCE_FETCH_TIMEOUTS: Lazy<Counter> = Lazy::new(|| {
+		register_counter!(opts!(
+			"staking_miner_balance_fetch_timeouts_total",
+			"Total number of balance fetch timeouts"
+		))
+		.unwrap()
+	});
+	static PHASE_CHECK_TIMEOUTS: Lazy<Counter> = Lazy::new(|| {
+		register_counter!(opts!(
+			"staking_miner_phase_check_timeouts_total",
+			"Total number of phase check timeouts"
+		))
+		.unwrap()
+	});
+	static SCORE_CHECK_TIMEOUTS: Lazy<Counter> = Lazy::new(|| {
+		register_counter!(opts!(
+			"staking_miner_score_check_timeouts_total",
+			"Total number of score check timeouts"
+		))
+		.unwrap()
+	});
+	static MISSING_PAGES_TIMEOUTS: Lazy<Counter> = Lazy::new(|| {
+		register_counter!(opts!(
+			"staking_miner_missing_pages_timeouts_total",
+			"Total number of missing pages submission timeouts"
 		))
 		.unwrap()
 	});
@@ -396,5 +452,29 @@ mod hidden {
 	}
 	pub fn on_submit_timeout() {
 		SUBMIT_TIMEOUTS.inc();
+	}
+	pub fn observe_balance_fetch_duration(duration_ms: f64) {
+		BALANCE_FETCH_DURATION.set(duration_ms);
+	}
+	pub fn on_balance_fetch_timeout() {
+		BALANCE_FETCH_TIMEOUTS.inc();
+	}
+	pub fn observe_phase_check_duration(duration_ms: f64) {
+		PHASE_CHECK_DURATION.set(duration_ms);
+	}
+	pub fn on_phase_check_timeout() {
+		PHASE_CHECK_TIMEOUTS.inc();
+	}
+	pub fn observe_score_check_duration(duration_ms: f64) {
+		SCORE_CHECK_DURATION.set(duration_ms);
+	}
+	pub fn on_score_check_timeout() {
+		SCORE_CHECK_TIMEOUTS.inc();
+	}
+	pub fn observe_missing_pages_duration(duration_ms: f64) {
+		MISSING_PAGES_DURATION.set(duration_ms);
+	}
+	pub fn on_missing_pages_timeout() {
+		MISSING_PAGES_TIMEOUTS.inc();
 	}
 }

--- a/src/prometheus.rs
+++ b/src/prometheus.rs
@@ -273,13 +273,6 @@ mod hidden {
 		))
 		.unwrap()
 	});
-	static TX_FINALIZATION_TIMEOUTS: Lazy<Counter> = Lazy::new(|| {
-		register_counter!(opts!(
-			"staking_miner_tx_finalization_timeouts_total",
-			"Total number of transaction finalization timeouts"
-		))
-		.unwrap()
-	});
 	static MINING_TIMEOUTS: Lazy<Counter> = Lazy::new(|| {
 		register_counter!(opts!(
 			"staking_miner_mining_timeouts_total",
@@ -391,9 +384,6 @@ mod hidden {
 
 	pub fn on_block_processing_stall() {
 		BLOCK_PROCESSING_STALLS.inc();
-	}
-	pub fn on_tx_finalization_timeout() {
-		TX_FINALIZATION_TIMEOUTS.inc();
 	}
 	pub fn on_mining_timeout() {
 		MINING_TIMEOUTS.inc();

--- a/src/prometheus.rs
+++ b/src/prometheus.rs
@@ -266,6 +266,13 @@ mod hidden {
 		))
 		.unwrap()
 	});
+	static MINING_TIMEOUTS: Lazy<Counter> = Lazy::new(|| {
+		register_counter!(opts!(
+			"staking_miner_mining_timeouts_total",
+			"Total number of solution mining timeouts"
+		))
+		.unwrap()
+	});
 
 	pub fn on_runtime_upgrade() {
 		RUNTIME_UPGRADES.inc();
@@ -346,5 +353,8 @@ mod hidden {
 	}
 	pub fn on_tx_finalization_timeout() {
 		TX_FINALIZATION_TIMEOUTS.inc();
+	}
+	pub fn on_mining_timeout() {
+		MINING_TIMEOUTS.inc();
 	}
 }

--- a/src/prometheus.rs
+++ b/src/prometheus.rs
@@ -259,6 +259,13 @@ mod hidden {
 		))
 		.unwrap()
 	});
+	static TX_FINALIZATION_TIMEOUTS: Lazy<Counter> = Lazy::new(|| {
+		register_counter!(opts!(
+			"staking_miner_tx_finalization_timeouts_total",
+			"Total number of transaction finalization timeouts"
+		))
+		.unwrap()
+	});
 
 	pub fn on_runtime_upgrade() {
 		RUNTIME_UPGRADES.inc();
@@ -336,5 +343,8 @@ mod hidden {
 
 	pub fn on_block_processing_stall() {
 		BLOCK_PROCESSING_STALLS.inc();
+	}
+	pub fn on_tx_finalization_timeout() {
+		TX_FINALIZATION_TIMEOUTS.inc();
 	}
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -18,7 +18,7 @@ use crate::{
 	client::Client,
 	commands::types::SubmissionStrategy,
 	error::Error,
-	prelude::{ChainClient, Config, Hash, Storage},
+	prelude::{ChainClient, Config, Hash, LOG_TARGET, Storage},
 };
 use pin_project_lite::pin_project;
 use polkadot_sdk::{sp_npos_elections, sp_runtime::Perbill};
@@ -105,11 +105,38 @@ pub fn score_passes_strategy(
 	}
 }
 
-/// Wait for the transaction to be included in a finalized block.
+/// Timeout for transaction finalization in seconds.
+/// Should be long enough to handle normal finalization delays but short enough to prevent
+/// indefinite hanging.
+const TX_FINALIZATION_TIMEOUT_SECS: u64 = 120;
+
+/// Wait for the transaction to be included in a finalized block with timeout.
+/// This prevents indefinite hanging if finalization is stalled.
 pub async fn wait_tx_in_finalized_block(
 	tx: TxProgress<Config, ChainClient>,
+	operation_context: &str,
 ) -> Result<TxInBlock<Config, ChainClient>, Error> {
-	tx.wait_for_finalized().await.map_err(Into::into)
+	match tokio::time::timeout(
+		std::time::Duration::from_secs(TX_FINALIZATION_TIMEOUT_SECS),
+		tx.wait_for_finalized(),
+	)
+	.await
+	{
+		Ok(result) => result.map_err(Into::into),
+		Err(_) => {
+			log::error!(
+				target: LOG_TARGET,
+				"Transaction finalization timed out after {} seconds for operation: {}",
+				TX_FINALIZATION_TIMEOUT_SECS,
+				operation_context
+			);
+			crate::prometheus::on_tx_finalization_timeout();
+			Err(Error::TxFinalizationTimeout {
+				operation: operation_context.to_string(),
+				timeout_secs: TX_FINALIZATION_TIMEOUT_SECS,
+			})
+		},
+	}
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Problem

The staking miner would occasionally hang indefinitely when detecting new rounds, causing repeated 90-second timeouts.
We have observed this pattern on WAH, usually after few days  / a week of normal operation.

```bash
[2m2025-08-15T05:58:47.601502Z[0m [34mDEBUG[0m [2mpolkadot-staking-miner[0m[2m:[0m Detected round increment 279 -> 280
[2m2025-08-15T05:58:47.601512Z[0m [35mTRACE[0m [2mpolkadot-staking-miner[0m[2m:[0m Sent janitor tick for round 280
[2m2025-08-15T05:58:47.601514Z[0m [34mDEBUG[0m [2mpolkadot-staking-miner[0m[2m:[0m Round increment in Off phase, signaling snapshot cleanup
[2m2025-08-15T05:58:47.601532Z[0m [35mTRACE[0m [2mpolkadot-staking-miner[0m[2m:[0m Running janitor cleanup for round 280
[2m2025-08-15T05:58:47.601636Z[0m [35mTRACE[0m [2mpolkadot-staking-miner[0m[2m:[0m Scanning round 279 for old submissions
[2m2025-08-15T05:58:47.709480Z[0m [35mTRACE[0m [2mpolkadot-staking-miner[0m[2m:[0m Janitor found no old submissions to clean up
[2m2025-08-15T06:00:17.454494Z[0m [33m WARN[0m [2mpolkadot-staking-miner[0m[2m:[0m Block processing timed out after 90s for block #12517171 - may indicate internal hang, recreating subscription...
[2m2025-08-15T06:00:17.454603Z[0m [32m INFO[0m [2mpolkadot-staking-miner[0m[2m:[0m Successfully recreated subscription after block processing timeout
[2m2025-08-15T06:00:17.454608Z[0m [32m INFO[0m [2mpolkadot-staking-miner[0m[2m:[0m Successfully processed subscription recreation after block processing timeout

```

While we initially suspected that the cleaning performed by the janitor task was the main culprit, improved logging and timeout handling introduced by #1119 and #1123 have shown that the miner task is already stuck when we attempt to trigger the cleanup task.

In one of the logs I have collected, the miner was busy processing a block from at least Signed(49) (before logs were truncated unfortunately...) until the end of the signed phase so it doesn't manage to successfully submit or bail during the whole `Signed` phase and hangs instead.

In another log, an RPC error was happening while in signed phase, and the miner task got stuck, see below. After that, once we detect a new round, again the miner is busy (stuck) while we are trying to clear snapshot.

```bash
[2m2025-08-04T21:13:23.366501Z[0m [35mTRACE[0m [2mpolkadot-staking-miner[0m[2m:[0m Signed phase with 33 blocks remaining - checking for mining opportunity
[2m2025-08-04T21:13:25.438966Z[0m [35mTRACE[0m [2mpolkadot-staking-miner[0m[2m:[0m Already submitted for round 243, skipping
[2m2025-08-04T21:13:25.440654Z[0m [35mTRACE[0m [2mpolkadot-staking-miner[0m[2m:[0m Block processing completed successfully
[2m2025-08-04T21:13:35.292217Z[0m [35mTRACE[0m [2mpolkadot-staking-miner[0m[2m:[0m Processing block=12429017 round=243, phase=Signed(32)
[2m2025-08-04T21:13:35.292235Z[0m [35mTRACE[0m [2mpolkadot-staking-miner[0m[2m:[0m Sent block #12429017 to miner
[2m2025-08-04T21:13:35.292251Z[0m [35mTRACE[0m [2mpolkadot-staking-miner[0m[2m:[0m Processing block #12429017 (round 243, phase Signed(32))
[2m2025-08-04T21:13:35.351058Z[0m [35mTRACE[0m [2mpolkadot-staking-miner[0m[2m:[0m Signed phase with 32 blocks remaining - checking for mining opportunity
[2m2025-08-04T21:13:37.487224Z[0m [35mTRACE[0m [2mpolkadot-staking-miner[0m[2m:[0m Already submitted for round 243, skipping
[2m2025-08-04T21:13:37.489408Z[0m [35mTRACE[0m [2mpolkadot-staking-miner[0m[2m:[0m Block processing completed successfully
[2m2025-08-04T21:13:39.522406Z[0m [35mTRACE[0m [2mpolkadot-staking-miner[0m[2m:[0m Processing block=12429018 round=243, phase=Signed(31)
[2m2025-08-04T21:13:39.522423Z[0m [35mTRACE[0m [2mpolkadot-staking-miner[0m[2m:[0m Sent block #12429018 to miner
[2m2025-08-04T21:13:39.522439Z[0m [35mTRACE[0m [2mpolkadot-staking-miner[0m[2m:[0m Processing block #12429018 (round 243, phase Signed(31))
[2m2025-08-04T21:13:39.582496Z[0m [35mTRACE[0m [2mpolkadot-staking-miner[0m[2m:[0m Signed phase with 31 blocks remaining - checking for mining opportunity
[2m2025-08-04T21:14:14.749599Z[0m [35mTRACE[0m [2mpolkadot-staking-miner[0m[2m:[0m Processing block=12429019 round=243, phase=Signed(30)
[2m2025-08-04T21:14:14.749623Z[0m [35mTRACE[0m [2mpolkadot-staking-miner[0m[2m:[0m Sent block #12429019 to miner
[2m2025-08-04T21:14:14.754007Z[0m [35mTRACE[0m [2mpolkadot-staking-miner[0m[2m:[0m upgrade to version: 1018013 failed: SameVersion
[2m2025-08-04T21:14:15.199361Z[0m [33m WARN[0m [2mpolkadot-staking-miner[0m[2m:[0m Non-critical listener error, continuing: Subxt(Rpc(ClientError(User(UserError { code: -32801, message: "Invalid block hash", data: None }))))
[2m2025-08-04T21:14:15.555986Z[0m [35mTRACE[0m [2mpolkadot-staking-miner[0m[2m:[0m Processing block=12429021 round=243, phase=Signed(28)
[2m2025-08-04T21:14:15.556006Z[0m [35mTRACE[0m [2mpolkadot-staking-miner[0m[2m:[0m Miner busy, skipping block #12429021
[2m2025-08-04T21:14:15.772017Z[0m [35mTRACE[0m [2mpolkadot-staking-miner[0m[2m:[0m Processing block=12429022 round=243, phase=Signed(27)

```

Various async operations (mining, submission, bailing plus all RPC operations like phase check, score check, missing page check) within the miner task had no timeout protection, allowing them to potentially hang forever.

## Solution

Implemented comprehensive timeout handling + logging + prometheus metrics at the high-level operation layer while processing a block in the miner task:

  - Mining operations: 10-minute timeout to handle complex elections
  - Bail operations: 2-minute timeout for reverting submissions
  - Submit operations: 30-minute timeout for multi-page submissions
  - Check existing submissions: 5-minute timeout for storage queries
  -  Balance fetch - 1 minute timeout 
  - Phase checks before bail operations - 1 minute timeout ()
  - Score competitiveness check - 1 minute timeout 
  - Missing pages submission - 30 minutes timeout 

For the time being, the timeout are hard-coded and should be pretty generous in terms of safety margins. We can fine-tune it or make it configurable (via command-line or environment variables for examples) later on, if needed.

The proposed solution should enable us to  
-  avoid the stalling issue  (🤞 )
-  log and track ad-hoc Prometheus metrics to identify where the timeout occurs. This will allow us to investigate which specific operation is causing the miner task to stall and improve iteratively.

##  Error handling

 - Added new `ErrorTimeout` type for  MiningTimeout, BailTimeout, SubmitTimeout, CheckExistingSubmissionTimeout, PhaseCheckTimeout, ScoreCheckTimeout, MissingPagesTimeout
  - All timeout errors are classified as recoverable (non-critical) - the miner continues operating

##  Metrics and observability

  - Added prometheus counters for timeout occurrences:
    - staking_miner_mining_timeouts_total
    - staking_miner_bail_timeouts_total
    - staking_miner_submit_timeouts_total
    - staking_miner_check_existing_submission_timeouts_total
    - staking_miner_phase_check_timeouts_total
    - staking_miner_score_check_timeouts_total
    - staking_miner_missing_pages_timeouts_total
    - staking_miner_balance_fetch_timeouts_total 
   
  - Added duration gauges for successful operations:
    - staking_miner_bail_duration_ms
    - staking_miner_check_existing_submission_duration_ms
    - staking_miner_phase_check_duration_ms
    - staking_miner_score_check_duration_ms
    - staking_miner_missing_pages_duration_ms
    - staking_miner_balance_fetch_duration_ms    

  ## Other fixes

  - Fixed prev_round update logic to prevent stale round detection after timeouts (with the miner task stuck, we entered in the condition where we were always detecting a new round between X and X+1 and triggering the janitor task at each new block received by the listener after recreating the subscription and before detecting another 90s stall)
  