### PR TITLE
Add subscription recreation retry limit to prevent infinite loops

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -87,6 +87,8 @@ pub enum Error {
 	WrongRound { solution_round: u32, current_round: u32 },
 	#[error("Operation timed out: {0}")]
 	Timeout(#[from] TimeoutError),
+	#[error("Exceeded maximum subscription recreation attempts ({max_attempts})")]
+	SubscriptionRecreationLimitExceeded { max_attempts: u32 },
 }
 
 impl From<subxt_rpcs::Error> for Error {


### PR DESCRIPTION
We have seen once on WAH the staking miner entering an infinite loop when blockchain subscriptions failed, continuously recreating subscriptions every 60 seconds without limit.

Whereas the root cause of the issue needs to be investigated and fixed, we prioritize a pragmatic approach by introducing the following:
- MAX_SUBSCRIPTION_RECREATION_ATTEMPTS constant (set to 3)
- Tracking of consecutive recreation attempts in listener task
- Process exit after 3 failed recreation attempts
- Specific SubscriptionRecreationLimitExceeded error type


Logs on WAH when the issue happened (note: so far, it happened once, and never on PAH)

```bash
2025-09-15T17:50:40.087584Z TRACE polkadot-staking-miner: get_block_state: Got current_phase in 78ms: Export(12)
2025-09-15T17:50:40.087606Z TRACE polkadot-staking-miner: get_block_state: Fetching round
2025-09-15T17:50:40.179040Z TRACE polkadot-staking-miner: get_block_state: Got round in 91ms: 390
2025-09-15T17:50:40.179058Z TRACE polkadot-staking-miner: Listener: Got block state in 170ms for block #12788465, phase: Export(12), round: 390
2025-09-15T17:50:40.179062Z TRACE polkadot-staking-miner: Block #12788465, Phase Export(12) - nothing to do
2025-09-15T17:50:40.179077Z TRACE polkadot-staking-miner: Listener: Waiting for next block from subscription...
2025-09-15T17:51:40.179968Z  WARN polkadot-staking-miner: No blocks received for 60 seconds - subscription may be stalled, recreating subscription...
2025-09-15T17:51:40.180012Z  INFO polkadot-staking-miner: Successfully recreated finalized block subscription
2025-09-15T17:51:40.180018Z  INFO polkadot-staking-miner: Successfully processed subscription recreation
2025-09-15T17:51:40.180021Z TRACE polkadot-staking-miner: Listener: Waiting for next block from subscription...
2025-09-15T17:52:40.180855Z  WARN polkadot-staking-miner: No blocks received for 60 seconds - subscription may be stalled, recreating subscription...
2025-09-15T17:52:40.180885Z  INFO polkadot-staking-miner: Successfully recreated finalized block subscription
2025-09-15T17:52:40.180889Z  INFO polkadot-staking-miner: Successfully processed subscription recreation
2025-09-15T17:52:40.180891Z TRACE polkadot-staking-miner: Listener: Waiting for next block from subscription...
2025-09-15T17:53:40.181883Z  WARN polkadot-staking-miner: No blocks received for 60 seconds - subscription may be stalled, recreating subscription...
2025-09-15T17:53:40.181915Z  INFO polkadot-staking-miner: Successfully recreated finalized block subscription
2025-09-15T17:53:40.181921Z  INFO polkadot-staking-miner: Successfully processed subscription recreation
2025-09-15T17:53:40.181924Z TRACE polkadot-staking-miner: Listener: Waiting for next block from subscription...
2025-09-15T17:54:40.183272Z  WARN polkadot-staking-miner: No blocks received for 60 seconds - subscription may be stalled, recreating subscription...
2025-09-15T17:54:40.183304Z  INFO polkadot-staking-miner: Successfully recreated finalized block subscription
2025-09-15T17:54:40.183309Z  INFO polkadot-staking-miner: Successfully processed subscription recreation
2025-09-15T17:54:40.183313Z TRACE polkadot-staking-miner: Listener: Waiting for next block from subscription...
2025-09-15T17:55:40.184841Z  WARN polkadot-staking-miner: No blocks received for 60 seconds - subscription may be stalled, recreating subscription...
2025-09-15T17:55:40.184870Z  INFO polkadot-staking-miner: Successfully recreated finalized block subscription
2025-09-15T17:55:40.184874Z  INFO polkadot-staking-miner: Successfully processed subscription recreation
2025-09-15T17:55:40.184877Z TRACE polkadot-staking-miner: Listener: Waiting for next block from subscription...
2025-09-15T17:56:40.185899Z  WARN polkadot-staking-miner: No blocks received for 60 seconds - subscription may be stalled, recreating subscription...
2025-09-15T17:56:40.185927Z  INFO polkadot-staking-miner: Successfully recreated finalized block subscription
2025-09-15T17:56:40.185930Z  INFO polkadot-staking-miner: Successfully processed subscription recreation
2025-09-15T17:56:40.185933Z TRACE polkadot-staking-miner: Listener: Waiting for next block from subscription...
2025-09-15T17:57:40.186863Z  WARN polkadot-staking-miner: No blocks received for 60 seconds - subscription may be stalled, recreating subscription...
2025-09-15T17:57:40.186895Z  INFO polkadot-staking-miner: Successfully recreated finalized block subscription
2025-09-15T17:57:40.186901Z  INFO polkadot-staking-miner: Successfully processed subscription recreation
2025-09-15T17:57:40.186904Z TRACE polkadot-staking-miner: Listener: Waiting for next block from subscription...
2025-09-15T17:58:40.187855Z  WARN polkadot-staking-miner: No blocks received for 60 seconds - subscription may be stalled, recreating subscription...
2025-09-15T17:58:40.187884Z  INFO polkadot-staking-miner: Successfully recreated finalized block subscription
2025-09-15T17:58:40.187888Z  INFO polkadot-staking-miner: Successfully processed subscription recreation
2025-09-15T17:58:40.187890Z TRACE polkadot-staking-miner: Listener: Waiting for next block from subscription...
2025-09-15T17:59:40.188372Z  WARN polkadot-staking-miner: No blocks received for 60 seconds - subscription may be stalled, recreating subscription...
2025-09-15T17:59:40.188402Z  INFO polkadot-staking-miner: Successfully recreated finalized block subscription
```