### PR TITLE
static-types: MaxVoters should match VoterSnapshotPerBlock

### DIFF
--- a/src/static_types/multi_block.rs
+++ b/src/static_types/multi_block.rs
@@ -26,7 +26,7 @@ pub mod node {
 			VoterIndex = u16,
 			TargetIndex = u16,
 			Accuracy = Percent,
-			MaxVoters = ConstU32::<22500>
+			MaxVoters = ConstU32::<704> // same default as Polkadot
 		>(16)
 	);
 
@@ -61,7 +61,7 @@ pub mod polkadot {
 			VoterIndex = u32,
 			TargetIndex = u16,
 			Accuracy = PerU16,
-			MaxVoters = ConstU32::<22500>
+			MaxVoters = ConstU32::<704> // should match VoterSnapshotPerBlock
 		>(16)
 	);
 
@@ -96,7 +96,7 @@ pub mod kusama {
 			VoterIndex = u32,
 			TargetIndex = u16,
 			Accuracy = PerU16,
-			MaxVoters = ConstU32::<12500>
+			MaxVoters = ConstU32::<782> // should match VoterSnapshotPerBlock
 		>(24)
 	);
 
@@ -131,7 +131,7 @@ pub mod westend {
 			VoterIndex = u32,
 			TargetIndex = u16,
 			Accuracy = PerU16,
-			MaxVoters = ConstU32::<22500>
+			MaxVoters = ConstU32::<703> // should match VoterSnapshotPerBlock
 		>(16)
 	);
 
@@ -167,7 +167,7 @@ pub mod staking_async {
 			VoterIndex = u32,
 			TargetIndex = u16,
 			Accuracy = PerU16,
-			MaxVoters = ConstU32::<22500>
+			MaxVoters = ConstU32::<704> // same default as Polkadot
 		>(16)
 	);
 


### PR DESCRIPTION
In the miner's NposSolution struct represents a single page solution where:

`MaxVoters = VoterSnapshotPerBlock = MaxElectingVoters::get().div_ceil(Pages::get()) `


This limits how many voters can be included per page of the solution, not the total snapshot.
The miner was incorrectly setting `MaxVoters = VoterSnapshotPerBlock * Pages` ending up overestimating the max numbers of voters per page. 

No actual damage in practice but let's make it proper.