### PR TITLE
fixed submission metrics

### DIFF
--- a/src/commands/multi_block/monitor.rs
+++ b/src/commands/multi_block/monitor.rs
@@ -1436,6 +1436,9 @@ where
 						}));
 					},
 				}
+				// The submission was started in an earlier process and has now been completed from
+				// here. Count the success so `started`/`success` match across the restart.
+				prometheus::on_submission_success();
 				return Ok(());
 			}
 

--- a/src/dynamic/multi_block.rs
+++ b/src/dynamic/multi_block.rs
@@ -400,9 +400,6 @@ pub(crate) async fn submit<T: MinerConfig + Send + Sync + 'static>(
 	round: u32,
 	min_signed_phase_blocks: u32,
 ) -> Result<(), Error> {
-	// Record that a submission has started
-	crate::prometheus::on_submission_started();
-
 	// 1. Get current phase and validate
 	let storage = utils::storage_at_head(client).await?;
 	let current_phase = utils::decode_storage_opt(
@@ -457,6 +454,9 @@ pub(crate) async fn submit<T: MinerConfig + Send + Sync + 'static>(
 	};
 
 	log::info!(target: LOG_TARGET, "Score registered at block {:?}", tx.block_hash());
+
+	// Only once `register_score` is confirmed on chain, the submission is considered started.
+	crate::prometheus::on_submission_started();
 
 	// 3. Get current phase and validate before submitting pages
 	let storage = utils::storage_at_head(client).await?;


### PR DESCRIPTION
- Made submission metrics  correctly track success across restart
- Submission is considered started only after `register_score` is registered on chain.

This aims to have a reliable [StakingMinerSuccessRateBelow80Percent](https://github.com/paritytech/devops-cloud-infra/blob/main/kubernetes/kube-prometheus-stack/files/parity-substrate-apps.rules#L41-L48) alarm and avoid false positive.