### PR TITLE
Cap chainHead pinned-block age to avoid server 'stop' events

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -26,20 +26,21 @@ const MAX_CONNECTION_ATTEMPTS: u32 = 3;
 /// Delay between connection attempts in seconds.
 const CONNECTION_RETRY_DELAY_SECS: u64 = 5;
 
-/// Maximum age (in finalized blocks) a pinned block is allowed to reach before subxt
-/// automatically unpins it.
-/// For a miner running against 2s-block AssetHub, this means 128s, for 500ms-block, 32s - still
-/// acceptable for normal tx finalization.
-/// Because subxt adds one entry to its pinned-blocks map per new finalized block and in the worst
-/// case removes one entry per block that ages past this limit, the map size plateaus at 64
-/// entries. That is well below the substrate chainHead server's 512-pin budget (see
-/// `MAX_PINNED_BLOCKS` in polkadot-sdk as used by default in ChainHeadConfig) and allows other
-/// concurrent subscriptions as well.
-/// Without this cap, subxt defaults to `usize::MAX` — the map is effectively unbounded — so it
-/// would grow until reaching the server's pin budget, at which point the server emits a `stop`
-/// event that kills in-flight transactions.
-/// If a tx exceeds the retention window it loses its pin and fails, but the miner's recovery path
-/// (`Incomplete` on chain → missing-pages branch) handles that cleanly on the next block.
+/// Maximum age (in finalized-block events) a pinned block is allowed to reach before subxt
+/// unpins it. The counter advances only on `FollowEvent::Finalized` (see
+/// `FollowStreamUnpin::next_rel_block_age` in subxt), so the window scales with finalization
+/// cadence: ~128s on 2s-block AssetHub, ~32s on 500ms blocks.
+/// Steady-state pinned-map size is ~64 finalized entries, still well below the substrate
+/// chainHead server's 512-pin budget (`MAX_PINNED_BLOCKS` in polkadot-sdk's default
+/// `ChainHeadConfig`), leaving headroom for concurrent subscriptions.
+/// Without this cap, subxt defaults to `usize::MAX`: the pinned map grows until it hits the
+/// server's budget, at which point the server emits a `stop` event that kills in-flight
+/// transactions.
+/// The cap does not itself produce a tx-level failure; subxt's `transaction_timeout_secs` (default:
+/// 240s) bounds tail latency independently.
+/// If a tx ever takes longer than the window to finalize, the block is age-unpinned server-side but
+/// the tx watch continues until subxt's timeout fires. The miner's recovery path then picks up
+/// cleanly on the next round.
 const MAX_BLOCK_LIFE: usize = 64;
 
 /// Wraps the subxt interfaces to make it easy to use for the staking-miner.

--- a/src/client.rs
+++ b/src/client.rs
@@ -26,21 +26,22 @@ const MAX_CONNECTION_ATTEMPTS: u32 = 3;
 /// Delay between connection attempts in seconds.
 const CONNECTION_RETRY_DELAY_SECS: u64 = 5;
 
-/// Maximum age (in finalized-block events) a pinned block is allowed to reach before subxt
-/// unpins it. The counter advances only on `FollowEvent::Finalized` (see
-/// `FollowStreamUnpin::next_rel_block_age` in subxt), so the window scales with finalization
-/// cadence: ~128s on 2s-block AssetHub, ~32s on 500ms blocks.
-/// Steady-state pinned-map size is ~64 finalized entries, still well below the substrate
-/// chainHead server's 512-pin budget (`MAX_PINNED_BLOCKS` in polkadot-sdk's default
-/// `ChainHeadConfig`), leaving headroom for concurrent subscriptions.
-/// Without this cap, subxt defaults to `usize::MAX`: the pinned map grows until it hits the
-/// server's budget, at which point the server emits a `stop` event that kills in-flight
-/// transactions.
-/// The cap does not itself produce a tx-level failure; subxt's `transaction_timeout_secs` (default:
-/// 240s) bounds tail latency independently.
-/// If a tx ever takes longer than the window to finalize, the block is age-unpinned server-side but
-/// the tx watch continues until subxt's timeout fires. The miner's recovery path then picks up
-/// cleanly on the next round.
+/// Maximum age (in finalized-block events) a pinned block can reach before subxt unpins it.
+/// The counter advances only on `FollowEvent::Finalized` (see
+/// `FollowStreamUnpin::next_rel_block_age` in subxt 0.50), so the window scales with
+/// finalization cadence: ~128s on 2s blocks, ~32s on 500ms — both well under subxt's default
+/// `transaction_timeout_secs` of 240s.
+///
+/// Without this cap, subxt defaults to `usize::MAX`: pinned blocks are released only when
+/// every caller `BlockRef` drops. In practice, each in-flight `submit_and_watch` retains
+/// `BlockRef`s to observed NewBlock/Finalized blocks for the full lifetime of the watch.
+/// The cumulative retention saturates the substrate server's 512-pin budget
+/// (`MAX_PINNED_BLOCKS` in polkadot-sdk's default `ChainHeadConfig`), at which point the
+/// server emits a `chainHead_follow 'stop'` that kills the in-flight tx.
+///
+/// The cap fires age-based unpin in `FollowStreamUnpin::unpin_blocks` unconditionally of
+/// caller `BlockRef` retention — the only subxt 0.50 lever that bypasses tx-watch
+/// retention. Pinned-map size stays at ~64, far below 512.
 const MAX_BLOCK_LIFE: usize = 64;
 
 /// Wraps the subxt interfaces to make it easy to use for the staking-miner.

--- a/src/client.rs
+++ b/src/client.rs
@@ -26,6 +26,22 @@ const MAX_CONNECTION_ATTEMPTS: u32 = 3;
 /// Delay between connection attempts in seconds.
 const CONNECTION_RETRY_DELAY_SECS: u64 = 5;
 
+/// Maximum age (in finalized blocks) a pinned block is allowed to reach before subxt
+/// automatically unpins it.
+/// For a miner running against 2s-block AssetHub, this means 128s, for 500ms-block, 32s - still
+/// acceptable for normal tx finalization.
+/// Because subxt adds one entry to its pinned-blocks map per new finalized block and in the worst
+/// case removes one entry per block that ages past this limit, the map size plateaus at 64
+/// entries. That is well below the substrate chainHead server's 512-pin budget (see
+/// `MAX_PINNED_BLOCKS` in polkadot-sdk as used by default in ChainHeadConfig) and allows other
+/// concurrent subscriptions as well.
+/// Without this cap, subxt defaults to `usize::MAX` — the map is effectively unbounded — so it
+/// would grow until reaching the server's pin budget, at which point the server emits a `stop`
+/// event that kills in-flight transactions.
+/// If a tx exceeds the retention window it loses its pin and fails, but the miner's recovery path
+/// (`Incomplete` on chain → missing-pages branch) handles that cleanly on the next block.
+const MAX_BLOCK_LIFE: usize = 64;
+
 /// Wraps the subxt interfaces to make it easy to use for the staking-miner.
 /// Supports multiple RPC endpoints with failover capability.
 #[derive(Clone, Debug)]
@@ -199,6 +215,7 @@ impl Client {
 				client
 			} else {
 				let backend: ChainHeadBackend<Config> = ChainHeadBackendBuilder::default()
+					.max_block_life(MAX_BLOCK_LIFE)
 					.build_with_background_driver(reconnecting_rpc.clone());
 				let client = ChainClient::from_backend(Arc::new(backend)).await?;
 				log::info!(target: LOG_TARGET, "Connected to {uri} with ChainHead backend");

--- a/src/commands/multi_block/monitor.rs
+++ b/src/commands/multi_block/monitor.rs
@@ -1917,6 +1917,13 @@ fn is_critical_miner_error(error: &Error) -> bool {
 		Error::WrongPageCount { .. } |
 		Error::WrongRound { .. } |
 		Error::Timeout(_) => false,
+		// chainHead_follow emits a `stop` event when the server asks the client to
+		// re-subscribe (e.g. pinned-block budget exceeded). Subxt's auto-resubscribes in the
+		// background, so the next tx uses a fresh subscription.
+		Error::Subxt(boxed_err)
+			if matches!(boxed_err.as_ref(), subxt::Error::Other(_)) &&
+				boxed_err.to_string().contains("chainHead_follow emitted 'stop' event") =>
+			false,
 		Error::Subxt(boxed_err)
 			if matches!(
 				boxed_err.as_ref(),

--- a/src/commands/multi_block/monitor.rs
+++ b/src/commands/multi_block/monitor.rs
@@ -1920,13 +1920,6 @@ fn is_critical_miner_error(error: &Error) -> bool {
 		Error::WrongPageCount { .. } |
 		Error::WrongRound { .. } |
 		Error::Timeout(_) => false,
-		// chainHead_follow emits a `stop` event when the server asks the client to
-		// re-subscribe (e.g. pinned-block budget exceeded). Subxt's auto-resubscribes in the
-		// background, so the next tx uses a fresh subscription.
-		Error::Subxt(boxed_err)
-			if matches!(boxed_err.as_ref(), subxt::Error::Other(_)) &&
-				boxed_err.to_string().contains("chainHead_follow emitted 'stop' event") =>
-			false,
 		Error::Subxt(boxed_err)
 			if matches!(
 				boxed_err.as_ref(),


### PR DESCRIPTION
## Problem 

Subxt's `ChainHead` backend defaults `max_block_life` to `usize::MAX`, so `FollowStreamUnpin::pinned` grows potentially without bound (with uncapped `max_block_life`, the only way a finalized block leaves `FollowStreamUnpin::pinned` is when its `BlockRef` is dropped by the miner AND the block is flagged unpinnable by subxt). 
Once it fills the substrate server's 512-pin budget (`ChainHeadConfig` default — a global cap across all subscriptions see [here](https://github.com/paritytech/polkadot-sdk/blob/master/substrate/client/rpc-spec-v2/src/chain_head/chain_head.rs#L107) and [here](https://github.com/paritytech/polkadot-sdk/blob/master/substrate/client/rpc-spec-v2/src/chain_head/chain_head.rs#L85-L85) ), the server emits `chainHead_follow` `stop`, killing in-flight transactions.

The accumulator lives inside subxt `0.50.0`'s `submit_transaction`: the per-tx-watch `seen_blocks` map holds a `BlockRef` per observed NewBlock/Finalized event for the full lifetime of each `submit_and_watch` call (up to 240s).

The miner itself - for a 32 page solution - holds no more than ~40 `BlockRefs`, the accumulation is subxt-internal, not miner-code.

The issue becomes (more?) visible on Polkadot AH with Elastic Scaling and the  the 6s => 2s block change since pin accumulation rate is ~3× faster on 2s blocks.

## Fix

Set `max_block_life = 64` on `ChainHeadBackendBuilder`. 

Subxt's age-based unpin in `FollowStreamUnpin::unpin_blocks` fires unconditionally of caller `BlockRef` retention, which is  theonly subxt 0.50 lever that bypasses the tx-watch retention above. 

64 finalized blocks ≈ 128s on 2s cadence, 32s on 500ms, both well under subxt's 240s tx timeout. 
`pinned` map plateaus at ~64, far below 512.

If a tx ever exceeds the window, subxt's tx timeout fires and the miner's existing recovery picks up on the next round.