### PR TITLE
fix: skip submitting solutions below on-chain minimum score

### DIFF
--- a/src/commands/multi_block/monitor.rs
+++ b/src/commands/multi_block/monitor.rs
@@ -13,7 +13,7 @@ use crate::{
 	},
 	signer::Signer,
 	static_types::multi_block as static_types,
-	utils::{self, TimedFuture, score_passes_strategy},
+	utils::{self, TimedFuture, meets_minimum_score, score_passes_strategy},
 };
 use codec::Decode;
 use futures::TryStreamExt;
@@ -545,7 +545,7 @@ enum EraPruningMessage {
 /// - **RPC issues**: Handled transparently by reconnecting RPC client
 ///
 /// ```text
-/// 
+///
 ///                      (finalized blocks)
 /// ┌──────────────────────────────────────────────────────────────────────────┐
 /// │  ┌─────────────┐                      ┌─────────────┐              ┌─────────────┐
@@ -1093,9 +1093,10 @@ where
 /// 3. Fetch missing snapshots if needed
 /// 4. Check if already submitted for this round
 /// 5. Mine the solution
-/// 6. Handle existing submissions (complete/incomplete)
-/// 7. Check score competitiveness
-/// 8. Submit the solution
+/// 6. Reject solutions below the on-chain minimum score (would be slashed as `ScoreTooLow`)
+/// 7. Handle existing submissions (complete/incomplete)
+/// 8. Check score competitiveness
+/// 9. Submit the solution
 ///
 /// No submission lock is needed since the miner task is single-threaded.
 /// Retransmission scenarios are handled after miner restarts or runtime upgrades.
@@ -1296,6 +1297,20 @@ where
 	// Handle shady behavior if enabled
 	if config.shady {
 		return execute_shady_behavior(&client, &signer, &phase).await;
+	}
+
+	// Reject solutions that cannot clear the on-chain minimum score. The verifier rejects any
+	// solution whose score does not strictly exceed `MinimumScore` with `ScoreTooLow` and slashes
+	// the submitter's deposit (see `MultiBlockElectionVerifier::ensure_score_quality`).
+	let minimum = fetch_minimum_score(&at_block).await?;
+	if !meets_minimum_score(paged_raw_solution.score, minimum) {
+		let minimum = minimum.expect("score fails the check only when a floor is set; qed");
+		log::warn!(
+			target: LOG_TARGET,
+			"Mined score {:?} for round {round} does not exceed on-chain minimum {minimum:?}; skipping submission to avoid a slashed deposit",
+			paged_raw_solution.score,
+		);
+		return Err(Error::ScoreBelowMinimum { score: paged_raw_solution.score, minimum });
 	}
 
 	// Handle existing submissions with timeout to prevent indefinite hanging
@@ -1579,6 +1594,20 @@ where
 	};
 
 	Ok(())
+}
+
+/// Fetch the on-chain minimum untrusted score floor, if one is set.
+///
+/// A solution whose score does not strictly exceed this floor is rejected by the verifier with
+/// `ScoreTooLow` and the submitter's deposit is slashed.
+async fn fetch_minimum_score(at_block: &AtBlock) -> Result<Option<ElectionScore>, Error> {
+	let minimum = utils::decode_storage_opt(
+		at_block
+			.storage()
+			.try_fetch(runtime::storage().multi_block_election_verifier().minimum_score(), ())
+			.await?,
+	)?;
+	Ok(minimum.map(|score| score.0))
 }
 
 /// Whether the computed score is better than the current best score
@@ -1922,6 +1951,7 @@ fn is_critical_miner_error(error: &Error) -> bool {
 		Error::SolutionValidation { .. } |
 		Error::WrongPageCount { .. } |
 		Error::WrongRound { .. } |
+		Error::ScoreBelowMinimum { .. } |
 		Error::Timeout(_) => false,
 		Error::Subxt(boxed_err)
 			if matches!(

--- a/src/commands/multi_block/monitor.rs
+++ b/src/commands/multi_block/monitor.rs
@@ -545,7 +545,7 @@ enum EraPruningMessage {
 /// - **RPC issues**: Handled transparently by reconnecting RPC client
 ///
 /// ```text
-///
+/// 
 ///                      (finalized blocks)
 /// ┌──────────────────────────────────────────────────────────────────────────┐
 /// │  ┌─────────────┐                      ┌─────────────┐              ┌─────────────┐

--- a/src/error.rs
+++ b/src/error.rs
@@ -116,6 +116,13 @@ pub enum Error {
 		"Wrong round: solution is for round {solution_round} but current round is {current_round}"
 	)]
 	WrongRound { solution_round: u32, current_round: u32 },
+	#[error(
+		"Mined solution score {score:?} does not exceed on-chain minimum score {minimum:?}; not submitting to avoid a slashed deposit"
+	)]
+	ScoreBelowMinimum {
+		score: polkadot_sdk::sp_npos_elections::ElectionScore,
+		minimum: polkadot_sdk::sp_npos_elections::ElectionScore,
+	},
 	#[error("Operation timed out: {0}")]
 	Timeout(#[from] TimeoutError),
 	#[error("Exceeded maximum subscription recreation attempts ({max_attempts})")]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -128,6 +128,18 @@ pub fn score_passes_strategy(
 	}
 }
 
+/// Returns `true` if `score` clears the on-chain minimum untrusted score floor.
+///
+/// Mirrors `MultiBlockElectionVerifier::ensure_score_quality`: with no floor set every solution
+/// qualifies, otherwise the score must be strictly better than the floor. A solution that does not
+/// clear the floor is rejected on-chain as `ScoreTooLow` and its deposit is slashed.
+pub fn meets_minimum_score(
+	score: sp_npos_elections::ElectionScore,
+	minimum: Option<sp_npos_elections::ElectionScore>,
+) -> bool {
+	minimum.is_none_or(|min| score.strict_better(min))
+}
+
 /// Wait for the transaction to be included in a finalized block.
 pub async fn wait_tx_in_finalized_block<C: subxt::client::OnlineClientAtBlockT<Config>>(
 	tx: TransactionProgress<Config, C>,
@@ -343,6 +355,38 @@ mod tests {
 		assert!(score_passes_strategy(s(102), s(100), SubmissionStrategy::ClaimNoWorseThan(two)));
 		assert!(score_passes_strategy(s(103), s(100), SubmissionStrategy::ClaimNoWorseThan(two)));
 		assert!(score_passes_strategy(s(150), s(100), SubmissionStrategy::ClaimNoWorseThan(two)));
+	}
+
+	#[test]
+	fn meets_minimum_score_works() {
+		// `strict_better` is lexicographic over all three axes in order of significance:
+		// `minimal_stake` (higher better), then `sum_stake` (higher better), then
+		// `sum_stake_squared` (lower better).
+		let score = |minimal_stake, sum_stake, sum_stake_squared| {
+			sp_npos_elections::ElectionScore { minimal_stake, sum_stake, sum_stake_squared }
+		};
+		let floor = score(100, 100, 100);
+
+		// WHEN no floor is set on-chain THEN any score qualifies.
+		assert!(meets_minimum_score(score(0, 0, 0), None));
+
+		// WHEN the score exactly equals the floor THEN it is rejected: the on-chain check requires
+		// a *strictly* better score, so submitting would be slashed as `ScoreTooLow`.
+		assert!(!meets_minimum_score(floor, Some(floor)));
+
+		// `minimal_stake` axis (dominant)
+		// A higher `minimal_stake` wins outright, even with worse `sum_stake`/`sum_stake_squared`.
+		assert!(meets_minimum_score(score(101, 0, 999), Some(floor)));
+		// A lower `minimal_stake` loses outright, even with better lower axes.
+		assert!(!meets_minimum_score(score(99, 999, 0), Some(floor)));
+
+		// `sum_stake` axis (tie-break when `minimal_stake` is equal)
+		assert!(meets_minimum_score(score(100, 101, 999), Some(floor)));
+		assert!(!meets_minimum_score(score(100, 99, 0), Some(floor)));
+
+		// `sum_stake_squared` axis (tie-break when the two above are equal; lower is better)
+		assert!(meets_minimum_score(score(100, 100, 99), Some(floor)));
+		assert!(!meets_minimum_score(score(100, 100, 101), Some(floor)));
 	}
 
 	#[test]


### PR DESCRIPTION
Check the mined score against `MultiBlockElectionVerifier::MinimumScore` before registering, instead of submitting and getting slashed for ScoreTooLow.

Closes #1290

Tested on Polkadot AH before ref 1914 is enacted: as expected, miner doesn't submit the solution (this would have prevented poor parity-miner and community-run miner to be slashed during the incident ref 1914 is fixing...)

```bash
2026-06-30T18:47:03.744135Z  INFO polkadot-staking-miner: Mining solution took 1054ms for block #17651684
2026-06-30T18:47:03.746133Z DEBUG polkadot-staking-miner: Solution validation passed: desired_targets (600) == solution winner count (600), pages (32) <= max (32), round (238) matches current (238)
2026-06-30T18:47:03.826389Z  WARN polkadot-staking-miner: Mined score ElectionScore { minimal_stake: 6751362182193749, sum_stake: 8114199381247966575, sum_stake_squared: 113422822440000997006315554731614285 } for round 238 does not exceed on-chain minimum ElectionScore { minimal_stake: 7895552765679931, sum_stake: 5655838551978860651, sum_stake_squared: 187148285683372481445131595645808873 }; skipping submission to avoid a slashed deposit
```

Example of successful submission coming from testing vs staking-async test runtime:

```bash
2026-06-30T19:25:27.076432Z  INFO polkadot-staking-miner: Mining solution took 9ms for block #6
2026-06-30T19:25:27.076506Z DEBUG polkadot-staking-miner: Solution validation passed: desired_targets (10) == solution winner count (10), pages (4) <= max (4), round (0) matches current (0)
2026-06-30T19:25:27.241232Z DEBUG polkadot-staking-miner: No existing submission found
2026-06-30T19:25:27.282044Z  INFO polkadot-staking-miner: Submitting solution with score ElectionScore { minimal_stake: 1217875712957780172366, sum_stake: 12178967026980835814895, sum_stake_squared: 340282366920938463463374607431768211455 } for round 0
2026-06-30T19:25:27.406008Z TRACE polkadot-staking-miner::multi-block: Signed phase has 39 blocks remaining, enough blocks to continue
2026-06-30T19:25:27.488051Z TRACE polkadot-staking-miner::multi-block: submit `register score` nonce=0
```
