### PR TITLE
feat: accept self-stake in predict candidates_include overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,7 +378,9 @@ When using `--overrides`, the file should have the following JSON structure:
 
 ```json
 {
-  "candidates_include": ["15S7YtETM31QxYYqubAwRJKRSM4v4Ua6WGFYnx1VuFBnWqdG"],
+  "candidates_include": [
+    ["15S7YtETM31QxYYqubAwRJKRSM4v4Ua6WGFYnx1VuFBnWqdG", 100000000000000]
+  ],
   "candidates_exclude": [],
   "voters_include": [
     ["15S7YtETM31QxYYqubAwRJKRSM4v4Ua6WGFYnx1VuFBnWqdG", 1000000, ["15S7YtETM31QxYYqubAwRJKRSM4v4Ua6WGFYnx1VuFBnWqdG"]]
@@ -386,6 +388,22 @@ When using `--overrides`, the file should have the following JSON structure:
   "voters_exclude": []
 }
 ```
+
+Each `candidates_include` entry is `[address, self_stake]`. Since self-stake now has a mandatory
+minimum, an injected candidate without one has no chance of being elected: the target snapshot
+carries no stake, so a candidate's self-stake only reaches the election as a vote for itself. The
+self-stake is therefore materialized as a self-vote, exactly like the implicit self-vote the chain
+builds for its own validators.
+
+`self_stake` is a raw integer in the same unit as the stakes already in the election data — the
+chain's `VoteWeight`, same as the stake in `voters_include`.
+
+An entry whose address is already in the fetched data **overrides** its self-stake, replacing that
+account's existing vote with the self-vote — that is how "what if this validator bonded N?" is
+expressed. `voters_include` is applied afterwards and therefore takes precedence over it.
+
+A bare address (`"candidates_include": ["15S7Yt…"]`, the pre-self-stake format) is still accepted:
+it registers the candidate with no self-stake and leaves that account's votes untouched.
 
 **Note:** Override file paths can be nested (e.g., `data/elections/overrides.json`). The tool will
 automatically resolve relative paths from the current working directory.
@@ -395,11 +413,11 @@ automatically resolve relative paths from the current working directory.
 1. **Data Source**: The tool first tries to fetch data from the chain's snapshot (if available),
    then falls back to the staking pallet. 
 
-2. **Overrides Application**: If `--overrides` is provided, the tool applies the specified modifications to the fetched candidates and voters:
-   - (1) Add candidates that may not exist on-chain.
-   - (2) Remove specific candidates from the election.
-   - (3) Add or override voters with custom stake amounts.
-   - (4) Remove specific voters from the election.
+2. **Overrides Application**: If `--overrides` is provided, the tool applies the specified modifications to the fetched candidates and voters, in this order:
+   - (1) Remove specific candidates from the election.
+   - (2) Add candidates that may not exist on-chain, with an optional self-stake.
+   - (3) Remove specific voters from the election.
+   - (4) Add or override voters with custom stake amounts.
 
 3. **Election Algorithm**: Runs the same Phragmén algorithm (`seq_phragmen`) used by Substrate chains
    to determine:
@@ -447,7 +465,9 @@ Runs a full election simulation and returns the predicted validator set and nomi
   "do_reduce": true,
   "algorithm": "SeqPhragmen",
   "overrides": {
-    "candidates_include": ["15S7YtETM31QxYYqubAwRJKRSM4v4Ua6WGFYnx1VuFBnWqdG"],
+    "candidates_include": [
+      ["15S7YtETM31QxYYqubAwRJKRSM4v4Ua6WGFYnx1VuFBnWqdG", 100000000000000]
+    ],
     "candidates_exclude": [],
     "voters_include": [
       ["15S7YtETM31QxYYqubAwRJKRSM4v4Ua6WGFYnx1VuFBnWqdG", 1000000, ["15S7YtETM31QxYYqubAwRJKRSM4v4Ua6WGFYnx1VuFBnWqdG"]]

--- a/src/commands/types.rs
+++ b/src/commands/types.rs
@@ -248,11 +248,33 @@ pub(crate) type ValidatorData = (AccountId, u128);
 // Custom Data File Format Types
 // ============================================================================
 
+/// Candidate to add to the election, optionally with an arbitrary self-stake.
+///
+/// Accepts either a bare address (`"addr"`, self-stake 0) or an `["addr", self_stake]` pair. A
+/// candidate's self-stake is what makes it electable, so injecting candidates that are not bonded
+/// on-chain requires the pair form.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(untagged)]
+pub enum CandidateInclude {
+	Address(String),
+	WithSelfStake(String, u64),
+}
+
+impl CandidateInclude {
+	/// Address and self-stake of the candidate; a bare address has no self-stake.
+	pub fn parts(&self) -> (&str, u64) {
+		match self {
+			Self::Address(address) => (address, 0),
+			Self::WithSelfStake(address, self_stake) => (address, *self_stake),
+		}
+	}
+}
+
 /// JSON format for election overrides
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ElectionOverrides {
 	#[serde(default)]
-	pub candidates_include: Vec<String>,
+	pub candidates_include: Vec<CandidateInclude>,
 	#[serde(default)]
 	pub candidates_exclude: Vec<String>,
 	#[serde(default)]

--- a/src/dynamic/election_data.rs
+++ b/src/dynamic/election_data.rs
@@ -27,7 +27,6 @@ use crate::{
 	dynamic::staking::{fetch_candidates, fetch_voters},
 	error::Error,
 	prelude::{AccountId, AtBlock, LOG_TARGET},
-	static_types::multi_block::VoterSnapshotPerBlock,
 	utils::{encode_account_id, planck_to_token, planck_to_token_u64, read_data_from_json_file},
 };
 
@@ -49,7 +48,7 @@ pub struct PredictionContext<'a> {
 /// Returns a single-page target snapshot and a Vec of voter pages
 pub(crate) fn convert_election_data_to_snapshots<T>(
 	candidates: Vec<ValidatorData>,
-	voters: Vec<NominatorData>,
+	mut voters: Vec<NominatorData>,
 	data_source: ElectionDataSource,
 ) -> Result<(TargetSnapshotPageOf<T>, Vec<VoterSnapshotPageOf<T>>), Error>
 where
@@ -83,7 +82,34 @@ where
 		);
 	}
 
-	let per_voter_page = VoterSnapshotPerBlock::get();
+	let per_voter_page = T::VoterSnapshotPerBlock::get();
+
+	// The miner mines at most `T::Pages` pages and bounds the voter pages to that many, so an extra
+	// page is dropped along with every voter in it. Worse, staking data is paginated
+	// strongest-first and then reversed below, which makes the dropped page the strongest one.
+	// Only overrides can exceed the capacity (fetched data is already truncated to it), so let the
+	// weakest voters make room instead, the way the chain's own snapshot keeps the strongest.
+	let capacity = (T::Pages::get() as usize).saturating_mul(per_voter_page as usize);
+	if capacity > 0 && voters.len() > capacity {
+		let mut by_stake: Vec<usize> = (0..voters.len()).collect();
+		by_stake.sort_unstable_by_key(|&i| std::cmp::Reverse(voters[i].1));
+		let dropped: HashSet<usize> = by_stake[capacity..].iter().copied().collect();
+
+		log::warn!(
+			target: LOG_TARGET,
+			"Voter count {} exceeds the snapshot capacity of {capacity}; dropping the {} weakest voters",
+			voters.len(),
+			dropped.len()
+		);
+
+		let mut index = 0;
+		voters.retain(|_| {
+			let keep = !dropped.contains(&index);
+			index += 1;
+			keep
+		});
+	}
+
 	let total_voters = voters.len();
 	log::trace!(
 		target: LOG_TARGET,
@@ -157,15 +183,47 @@ pub(crate) fn apply_overrides(
 
 	candidates.retain(|(account, _)| !candidates_exclude.contains(account));
 
-	// (2) Add candidates that may not exist on-chain
-	let current_candidates: HashSet<AccountId> =
-		candidates.iter().map(|(a, _)| a.clone()).collect();
-	for c_str in overrides.candidates_include {
-		let account = c_str
+	// (2) Add candidates that may not exist on-chain, with an optional self-stake.
+	//
+	// The target snapshot carries no stake, so a candidate's self-stake only reaches the election
+	// through the voter snapshot, as a voter whose sole target is itself (what the chain calls an
+	// implicit self-vote). A candidate without one has zero approval stake and can never be
+	// elected, hence each self-stake is materialized as a self-vote below.
+	//
+	// An entry for an account already present OVERRIDES its self-stake, replacing any existing
+	// vote of that account with the self-vote. This is what makes "what if validator X bonded N?"
+	// expressible. `voters_include` is applied afterwards and therefore wins over it.
+	//
+	// A bare address (no self-stake, the legacy format) only registers the candidate and leaves
+	// the account's votes untouched.
+	for candidate_include in &overrides.candidates_include {
+		let (address, self_stake) = candidate_include.parts();
+		let account = address
 			.parse::<AccountId>()
-			.map_err(|e| Error::Other(format!("Invalid candidate include {c_str}: {e}")))?;
-		if !current_candidates.contains(&account) {
-			candidates.push((account, 0));
+			.map_err(|e| Error::Other(format!("Invalid candidate include {address}: {e}")))?;
+
+		match candidates.iter_mut().find(|(a, _)| a == &account) {
+			Some((_, stake)) => *stake = u128::from(self_stake),
+			None => candidates.push((account.clone(), u128::from(self_stake))),
+		}
+
+		if self_stake == 0 {
+			continue;
+		}
+
+		let self_vote = (account.clone(), self_stake, vec![account.clone()]);
+		match voters.iter_mut().find(|(a, _, _)| a == &account) {
+			Some(voter) => {
+				if voter.2 != self_vote.2 {
+					log::warn!(
+						target: LOG_TARGET,
+						"Candidate include {address}: replacing its {} existing nomination(s) with a self-vote of {self_stake}",
+						voter.2.len()
+					);
+				}
+				*voter = self_vote;
+			},
+			None => voters.push(self_vote),
 		}
 	}
 
@@ -495,8 +553,62 @@ where
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::commands::types::ElectionOverrides;
-	use polkadot_sdk::sp_core::crypto::Ss58Codec;
+	use crate::{
+		commands::types::{CandidateInclude, ElectionOverrides},
+		dynamic::multi_block::mine_solution,
+		prelude::{Accuracy, Hash},
+		static_types::multi_block::{BalancingIterations, DynamicSolver},
+	};
+	use polkadot_sdk::{
+		frame_election_provider_support, frame_support,
+		sp_core::crypto::Ss58Codec,
+		sp_runtime::{PerU16, traits::ConstU32},
+	};
+
+	const UNIT: u64 = 1_000_000_000_000;
+
+	const TEST_PAGES: u32 = 1;
+	const TEST_VOTERS_PER_PAGE: u32 = 100;
+
+	frame_election_provider_support::generate_solution_type!(
+		#[compact]
+		pub struct TestNposSolution16::<
+			VoterIndex = u32,
+			TargetIndex = u16,
+			Accuracy = PerU16,
+			MaxVoters = ConstU32::<TEST_VOTERS_PER_PAGE>
+		>(16)
+	);
+
+	pub struct TestMinerConfig;
+
+	impl MinerConfig for TestMinerConfig {
+		type AccountId = AccountId;
+		type Solution = TestNposSolution16;
+		type Solver = DynamicSolver<AccountId, Accuracy, BalancingIterations>;
+		type Pages = ConstU32<TEST_PAGES>;
+		type MaxVotesPerVoter = ConstU32<16>;
+		type MaxWinnersPerPage = ConstU32<10>;
+		type MaxBackersPerWinner = ConstU32<16>;
+		type MaxBackersPerWinnerFinal = ConstU32<{ u32::MAX }>;
+		type VoterSnapshotPerBlock = ConstU32<TEST_VOTERS_PER_PAGE>;
+		type TargetSnapshotPerBlock = ConstU32<1000>;
+		type MaxLength = ConstU32<{ 1024 * 1024 }>;
+		type Hash = Hash;
+	}
+
+	fn account(id: u8) -> AccountId {
+		AccountId::from([id; 32])
+	}
+
+	fn no_overrides() -> ElectionOverrides {
+		ElectionOverrides {
+			candidates_include: vec![],
+			candidates_exclude: vec![],
+			voters_include: vec![],
+			voters_exclude: vec![],
+		}
+	}
 
 	#[test]
 	fn test_apply_overrides_logic() {
@@ -521,7 +633,7 @@ mod tests {
 		// - Remove acc3 voter
 		// - Add acc4 voter with targets [acc2, acc4]
 		let overrides = ElectionOverrides {
-			candidates_include: vec![s4.clone()],
+			candidates_include: vec![CandidateInclude::Address(s4.clone())],
 			candidates_exclude: vec![s1.clone()],
 			voters_include: vec![(s4.clone(), 1500, vec![s2.clone(), s4.clone()])],
 			voters_exclude: vec![s3.clone()],
@@ -532,13 +644,263 @@ mod tests {
 		// Check candidates
 		assert_eq!(new_candidates.len(), 2);
 		assert!(new_candidates.iter().any(|(a, _)| a == &acc2));
-		assert!(new_candidates.iter().any(|(a, _)| a == &acc4));
+		assert!(new_candidates.iter().any(|(a, s)| a == &acc4 && *s == 0));
 		assert!(!new_candidates.iter().any(|(a, _)| a == &acc1));
 
-		// Check voters
+		// Check voters: a bare address adds no self-vote, so acc4 only votes via voters_include
 		assert_eq!(new_voters.len(), 1);
 		assert_eq!(new_voters[0].0, acc4);
 		assert_eq!(new_voters[0].1, 1500);
 		assert_eq!(new_voters[0].2, vec![acc2, acc4]);
+	}
+
+	/// A candidate self-stake must show up as a self-vote, otherwise the election never sees it.
+	#[test]
+	fn candidate_include_self_stake_adds_self_vote() {
+		// GIVEN one on-chain candidate backed by one nominator
+		let (existing, injected, bare, nominator) =
+			(account(1), account(9), account(8), account(3));
+		let candidates = vec![(existing.clone(), 1000)];
+		let voters = vec![(nominator.clone(), 500, vec![existing.clone()])];
+
+		// WHEN two candidates are injected, only one of them with a self-stake
+		let overrides = ElectionOverrides {
+			candidates_include: vec![
+				CandidateInclude::WithSelfStake(injected.to_ss58check(), 7 * UNIT),
+				CandidateInclude::Address(bare.to_ss58check()),
+			],
+			..no_overrides()
+		};
+		let (candidates, voters) = apply_overrides(candidates, voters, overrides).unwrap();
+
+		// THEN both are candidates, but only the one with a self-stake votes for itself
+		assert!(candidates.iter().any(|(a, s)| a == &injected && *s == u128::from(7 * UNIT)));
+		assert!(candidates.iter().any(|(a, s)| a == &bare && *s == 0));
+		assert_eq!(
+			voters,
+			vec![(nominator, 500, vec![existing]), (injected.clone(), 7 * UNIT, vec![injected]),]
+		);
+	}
+
+	/// Injecting an account that is already in the data overrides its self-stake, so that
+	/// "what if this validator raised its self-stake, keeping its nominators?" is expressible:
+	/// only the validator's own self-vote is rewritten, the votes cast *into* it are left alone.
+	#[test]
+	fn candidate_include_self_stake_overrides_existing_stake() {
+		// GIVEN a candidate that already self-votes, and a nominator of that candidate
+		let (validator, nominator) = (account(1), account(3));
+		let candidates = vec![(validator.clone(), u128::from(UNIT))];
+		let voters = vec![
+			(validator.clone(), UNIT, vec![validator.clone()]),
+			(nominator.clone(), 500, vec![validator.clone()]),
+		];
+
+		// WHEN the same account is injected with a higher self-stake
+		let overrides = ElectionOverrides {
+			candidates_include: vec![CandidateInclude::WithSelfStake(
+				validator.to_ss58check(),
+				9 * UNIT,
+			)],
+			..no_overrides()
+		};
+		let (candidates, voters) = apply_overrides(candidates, voters, overrides).unwrap();
+
+		// THEN its self-vote is updated in place, leaving everything else alone
+		assert_eq!(candidates, vec![(validator.clone(), u128::from(9 * UNIT))]);
+		assert_eq!(
+			voters,
+			vec![
+				(validator.clone(), 9 * UNIT, vec![validator]),
+				(nominator, 500, vec![account(1)]),
+			]
+		);
+	}
+
+	/// Turning a nominator into a candidate replaces its nominations with the self-vote.
+	#[test]
+	fn candidate_include_self_stake_replaces_nominations() {
+		let (nominator, target_a, target_b) = (account(3), account(1), account(2));
+		let voters = vec![(nominator.clone(), 500, vec![target_a, target_b])];
+
+		let overrides = ElectionOverrides {
+			candidates_include: vec![CandidateInclude::WithSelfStake(
+				nominator.to_ss58check(),
+				4 * UNIT,
+			)],
+			..no_overrides()
+		};
+		let (candidates, voters) = apply_overrides(vec![], voters, overrides).unwrap();
+
+		assert_eq!(candidates, vec![(nominator.clone(), u128::from(4 * UNIT))]);
+		assert_eq!(voters, vec![(nominator.clone(), 4 * UNIT, vec![nominator])]);
+	}
+
+	/// `voters_include` is applied after the candidate self-votes, so it stays the final word.
+	#[test]
+	fn voters_include_wins_over_candidate_self_stake() {
+		let injected = account(9);
+		let overrides = ElectionOverrides {
+			candidates_include: vec![CandidateInclude::WithSelfStake(
+				injected.to_ss58check(),
+				7 * UNIT,
+			)],
+			voters_include: vec![(
+				injected.to_ss58check(),
+				2 * UNIT,
+				vec![injected.to_ss58check()],
+			)],
+			..no_overrides()
+		};
+
+		let (_, voters) = apply_overrides(vec![], vec![], overrides).unwrap();
+
+		assert_eq!(voters, vec![(injected.clone(), 2 * UNIT, vec![injected])]);
+	}
+
+	/// A voter added by an override must not push the snapshot past its page capacity: the miner
+	/// bounds the voter pages to `T::Pages`, so the extra page is dropped with every voter in it —
+	/// and after the strongest-first pagination is reversed, that page is the strongest one.
+	#[test]
+	fn overrides_beyond_snapshot_capacity_drop_the_weakest_voters() {
+		let capacity = (TEST_PAGES * TEST_VOTERS_PER_PAGE) as usize;
+
+		// GIVEN a voter set exactly at capacity, strongest first as staking data arrives
+		let voters: Vec<NominatorData> = (0..capacity)
+			.map(|i| {
+				let who = account((i + 1) as u8);
+				(who.clone(), (capacity - i) as u64 * UNIT, vec![who])
+			})
+			.collect();
+		let strongest = voters[0].0.clone();
+		let weakest = voters[capacity - 1].0.clone();
+		let injected = account(200);
+
+		// WHEN an override injects one more voter, as a candidate self-stake does
+		let overrides = ElectionOverrides {
+			candidates_include: vec![CandidateInclude::WithSelfStake(
+				injected.to_ss58check(),
+				50 * UNIT,
+			)],
+			..no_overrides()
+		};
+		let (candidates, voters) = apply_overrides(vec![], voters, overrides).unwrap();
+		let (_, voter_snapshot) = convert_election_data_to_snapshots::<TestMinerConfig>(
+			candidates,
+			voters,
+			ElectionDataSource::Staking,
+		)
+		.unwrap();
+
+		// THEN the snapshot still fits in `Pages` pages, and the weakest voter is what made room
+		assert_eq!(voter_snapshot.len(), TEST_PAGES as usize);
+		let voters: Vec<AccountId> = voter_snapshot
+			.iter()
+			.flat_map(|page| page.iter().map(|(who, _, _)| who.clone()))
+			.collect();
+		assert_eq!(voters.len(), capacity);
+		assert!(voters.contains(&injected), "injected voter dropped");
+		assert!(voters.contains(&strongest), "strongest voter dropped");
+		assert!(!voters.contains(&weakest), "weakest voter kept");
+	}
+
+	/// Run the offline part of the predict pipeline: overrides -> snapshots -> mine -> prediction.
+	async fn predict(
+		candidates: Vec<ValidatorData>,
+		voters: Vec<NominatorData>,
+		overrides: ElectionOverrides,
+		desired_targets: u32,
+	) -> ValidatorsPrediction {
+		let (candidates, voters) = apply_overrides(candidates, voters, overrides).unwrap();
+		let (target_snapshot, voter_snapshot) =
+			convert_election_data_to_snapshots::<TestMinerConfig>(
+				candidates,
+				voters,
+				ElectionDataSource::Staking,
+			)
+			.unwrap();
+
+		let solution = mine_solution::<TestMinerConfig>(
+			target_snapshot.clone(),
+			voter_snapshot.clone(),
+			1,
+			0,
+			desired_targets,
+			0,
+			false,
+		)
+		.await
+		.unwrap();
+
+		let ctx = PredictionContext {
+			round: 0,
+			desired_targets,
+			block_number: 0,
+			ss58_prefix: 0,
+			token_decimals: 0,
+			token_symbol: "PLANCK",
+			data_source: ElectionDataSource::Staking,
+		};
+
+		build_predictions_from_solution::<TestMinerConfig>(
+			&solution,
+			&target_snapshot,
+			&voter_snapshot,
+			&ctx,
+		)
+		.unwrap()
+		.0
+	}
+
+	/// An injected candidate is only electable through its overridden self-stake, and the election
+	/// credits it with exactly that stake.
+	#[tokio::test]
+	async fn injected_candidate_is_elected_by_its_self_stake() {
+		// GIVEN three self-voting candidates competing for three seats, and an off-chain account
+		let (weakest, injected) = (account(3), account(9));
+		let candidates: Vec<ValidatorData> =
+			vec![(account(1), 0), (account(2), 0), (weakest.clone(), 0)];
+		let voters: Vec<NominatorData> = vec![
+			(account(1), 3 * UNIT, vec![account(1)]),
+			(account(2), 2 * UNIT, vec![account(2)]),
+			(weakest.clone(), UNIT, vec![weakest.clone()]),
+		];
+		let desired_targets = 3;
+		let injected_ss58 = encode_account_id(&injected, 0);
+		let weakest_ss58 = encode_account_id(&weakest, 0);
+
+		// WHEN it is injected as a candidate with a self-stake beating the weakest validator
+		let with_self_stake = ElectionOverrides {
+			candidates_include: vec![CandidateInclude::WithSelfStake(
+				injected.to_ss58check(),
+				5 * UNIT,
+			)],
+			..no_overrides()
+		};
+		let elected =
+			predict(candidates.clone(), voters.clone(), with_self_stake, desired_targets).await;
+
+		// THEN it takes a seat with exactly the overridden self-stake, evicting the weakest one
+		let winners: Vec<&str> = elected.results.iter().map(|v| v.account.as_str()).collect();
+		assert_eq!(winners.len(), desired_targets as usize);
+		assert!(winners.contains(&injected_ss58.as_str()), "injected candidate not elected");
+		assert!(!winners.contains(&weakest_ss58.as_str()), "weakest validator not evicted");
+
+		let injected_info =
+			elected.results.iter().find(|v| v.account == injected_ss58).expect("elected");
+		assert_eq!(injected_info.self_stake, "5000000000000 PLANCK");
+		assert_eq!(injected_info.total_stake, "5000000000000 PLANCK");
+		assert_eq!(injected_info.nominator_count, 0);
+
+		// WHEN the same account is injected without a self-stake (legacy bare address)
+		let without_self_stake = ElectionOverrides {
+			candidates_include: vec![CandidateInclude::Address(injected.to_ss58check())],
+			..no_overrides()
+		};
+		let not_elected = predict(candidates, voters, without_self_stake, desired_targets).await;
+
+		// THEN it has no backing and cannot win: the original three keep their seats
+		let winners: Vec<&str> = not_elected.results.iter().map(|v| v.account.as_str()).collect();
+		assert!(!winners.contains(&injected_ss58.as_str()), "candidate elected without stake");
+		assert!(winners.contains(&weakest_ss58.as_str()), "weakest validator lost its seat");
 	}
 }

--- a/src/dynamic/election_data.rs
+++ b/src/dynamic/election_data.rs
@@ -88,7 +88,7 @@ where
 	// page is dropped along with every voter in it. Worse, staking data is paginated
 	// strongest-first and then reversed below, which makes the dropped page the strongest one.
 	// Only overrides can exceed the capacity (fetched data is already truncated to it), so let the
-	// weakest voters make room instead, the way the chain's own snapshot keeps the strongest.
+	// weakest voters make room instead: everyone is ranked by stake and the tail is cut.
 	let capacity = (T::Pages::get() as usize).saturating_mul(per_voter_page as usize);
 	if capacity > 0 && voters.len() > capacity {
 		let mut by_stake: Vec<usize> = (0..voters.len()).collect();
@@ -801,6 +801,50 @@ mod tests {
 		assert!(voters.contains(&injected), "injected voter dropped");
 		assert!(voters.contains(&strongest), "strongest voter dropped");
 		assert!(!voters.contains(&weakest), "weakest voter kept");
+	}
+
+	/// An injected self-stake competes for a snapshot slot like any other voter rather than being
+	/// forced in: on chain, whether a validator's self-stake reaches the election depends on where
+	/// it lands in the bags list, so a self-stake too small to make the cut must not displace a
+	/// stronger voter.
+	#[test]
+	fn an_injected_self_stake_too_small_to_make_the_cut_is_dropped() {
+		let capacity = (TEST_PAGES * TEST_VOTERS_PER_PAGE) as usize;
+
+		// GIVEN a voter set exactly at capacity, the weakest of them holding one UNIT
+		let voters: Vec<NominatorData> = (0..capacity)
+			.map(|i| {
+				let who = account((i + 1) as u8);
+				(who.clone(), (capacity - i) as u64 * UNIT, vec![who])
+			})
+			.collect();
+		let weakest = voters[capacity - 1].0.clone();
+		let injected = account(200);
+
+		// WHEN a candidate is injected with a self-stake below all of them
+		let overrides = ElectionOverrides {
+			candidates_include: vec![CandidateInclude::WithSelfStake(
+				injected.to_ss58check(),
+				UNIT / 2,
+			)],
+			..no_overrides()
+		};
+		let (candidates, voters) = apply_overrides(vec![], voters, overrides).unwrap();
+		let (_, voter_snapshot) = convert_election_data_to_snapshots::<TestMinerConfig>(
+			candidates,
+			voters,
+			ElectionDataSource::Staking,
+		)
+		.unwrap();
+
+		// THEN it is the injected voter that makes room, and the existing set is untouched
+		let voters: Vec<AccountId> = voter_snapshot
+			.iter()
+			.flat_map(|page| page.iter().map(|(who, _, _)| who.clone()))
+			.collect();
+		assert_eq!(voters.len(), capacity);
+		assert!(!voters.contains(&injected), "injected voter forced in");
+		assert!(voters.contains(&weakest), "existing voter displaced by a weaker self-stake");
 	}
 
 	/// Run the offline part of the predict pipeline: overrides -> snapshots -> mine -> prediction.

--- a/tests/predict.rs
+++ b/tests/predict.rs
@@ -140,7 +140,7 @@ fn test_output_files_creation() {
 /// Create a temporary overrides file for testing
 fn create_test_overrides_file(temp_dir: &TempDir) -> std::path::PathBuf {
 	let overrides_data = serde_json::json!({
-		"candidates_include": ["15S7YtETM31QxYYqubAwRJKRSM4v4Ua6WGFYnx1VuFBnWqdG"],
+		"candidates_include": [["15S7YtETM31QxYYqubAwRJKRSM4v4Ua6WGFYnx1VuFBnWqdG", 100_000_000_000_000u64]],
 		"candidates_exclude": [],
 		"voters_include": [
 			["15S7YtETM31QxYYqubAwRJKRSM4v4Ua6WGFYnx1VuFBnWqdG", 1000000, ["15S7YtETM31QxYYqubAwRJKRSM4v4Ua6WGFYnx1VuFBnWqdG"]]
@@ -166,8 +166,27 @@ fn test_overrides_file_format_validation() {
 
 	// Validate structure
 	assert_eq!(parsed.candidates_include.len(), 1);
+	assert_eq!(
+		parsed.candidates_include[0].parts(),
+		("15S7YtETM31QxYYqubAwRJKRSM4v4Ua6WGFYnx1VuFBnWqdG", 100_000_000_000_000)
+	);
 	assert_eq!(parsed.voters_include.len(), 1);
 	assert_eq!(parsed.voters_include[0].1, 1000000);
+}
+
+#[test]
+fn test_overrides_file_bare_candidate_address_still_parses() {
+	let overrides_data = serde_json::json!({
+		"candidates_include": ["15S7YtETM31QxYYqubAwRJKRSM4v4Ua6WGFYnx1VuFBnWqdG"],
+	});
+
+	let parsed: polkadot_staking_miner::commands::types::ElectionOverrides =
+		serde_json::from_value(overrides_data).unwrap();
+
+	assert_eq!(
+		parsed.candidates_include[0].parts(),
+		("15S7YtETM31QxYYqubAwRJKRSM4v4Ua6WGFYnx1VuFBnWqdG", 0)
+	);
 }
 
 /// Test invalid overrides file format

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -8,9 +8,9 @@ use polkadot_staking_miner::{
 	commands::{
 		server::{MAX_BODY_SIZE, MAX_CONCURRENT_PREDICTIONS, ServerHandler, serve},
 		types::{
-			ElectionAlgorithm, ElectionDataSource, NominatorsPrediction, OverridesConfig,
-			PredictConfig, PredictionMetadata, ServerConfig, SnapshotConfig, SnapshotResult,
-			ValidatorsPrediction,
+			CandidateInclude, ElectionAlgorithm, ElectionDataSource, NominatorsPrediction,
+			OverridesConfig, PredictConfig, PredictionMetadata, ServerConfig, SnapshotConfig,
+			SnapshotResult, ValidatorsPrediction,
 		},
 	},
 	error::Error,
@@ -98,18 +98,27 @@ fn test_overrides_config_parsing() {
 		_ => panic!("Expected Path override"),
 	}
 
-	// Test JSON parsing (API style)
+	// Test JSON parsing (API style): candidates_include takes bare addresses and
+	// [address, self_stake] pairs.
 	let json_payload = r#"{
 		"do_reduce": true,
 		"overrides": {
-			"candidates_include": ["acc1"],
+			"candidates_include": ["acc1", ["acc3", 100000000000000]],
 			"voters_include": [["acc2", 1000, ["acc1"]]]
 		}
 	}"#;
 	let config: PredictConfig = serde_json::from_str(json_payload).unwrap();
 	match config.overrides {
 		Some(OverridesConfig::Data(data)) => {
-			assert_eq!(data.candidates_include, vec!["acc1".to_string()]);
+			assert_eq!(
+				data.candidates_include,
+				vec![
+					CandidateInclude::Address("acc1".to_string()),
+					CandidateInclude::WithSelfStake("acc3".to_string(), 100_000_000_000_000),
+				]
+			);
+			assert_eq!(data.candidates_include[0].parts(), ("acc1", 0));
+			assert_eq!(data.candidates_include[1].parts(), ("acc3", 100_000_000_000_000));
 			assert_eq!(data.voters_include.len(), 1);
 		},
 		_ => panic!("Expected Data override"),


### PR DESCRIPTION
`candidates_include` entries take an optional self-stake as `["addr", stake]`. The target snapshot carries no stake, so a candidate's self-stake only reaches the election through the voter snapshot. Each entry therefore materializes a self-vote, as the chain does for its own validators.

An entry for an account already in the fetched data overrides its self-stake, rewriting only that account's own vote and leaving votes cast into it untouched, which makes "raise validator X's self-stake, keeping its nominators" expressible. `voters_include` is applied afterwards and takes precedence. Bare addresses keep parsing, with no self-stake.

Also cap the voter set at `Pages * VoterSnapshotPerBlock` when overrides exceed it.

Closes #1300.