### PR TITLE
fix: unbreak the integration-tests build and check it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,9 @@ jobs:
       - name: Check code
         run: |
           ${{ env.RUST_INFO }}
-          cargo check --workspace --all-targets
+          # --all-features so the `integration-tests` gated tests/monitor.rs is compiled here too,
+          # instead of breaking nightly.yml a day after the PR merges.
+          cargo check --workspace --all-targets --all-features
 
   test:
     name: Run tests

--- a/tests/monitor.rs
+++ b/tests/monitor.rs
@@ -2,7 +2,7 @@
 //! Integration tests for the multi-block monitor (pallet-election-multi-block).
 //! See nightly.yml for instructions on how to run it compared vs a zombienet setup.
 use polkadot_staking_miner::{
-	prelude::ChainClient,
+	prelude::{AtBlock, ChainClient},
 	runtime::multi_block::{
 		self as runtime,
 		multi_block_election_signed::events::{Discarded, Registered, Rewarded, Slashed, Stored},
@@ -301,8 +301,6 @@ struct PalletConstants {
 	signed_validation_phase: u32,
 	unsigned_phase: u32,
 }
-
-type AtBlock = subxt::OnlineClientAtBlock<subxt::PolkadotConfig>;
 
 /// Read the MultiBlockElection pallet constants
 async fn read_pallet_constants(at_block: &AtBlock) -> anyhow::Result<PalletConstants> {


### PR DESCRIPTION
`prelude::Config` became `StakingMinerConfig` in #1302, but tests/monitor.rs kept its own `AtBlock` alias pinned to `subxt::PolkadotConfig`, so `read_pallet_constants` stopped accepting the client it is handed:

```
    error[E0308]: expected `&ClientAtBlock<PolkadotConfig, ...>`
                     found `&ClientAtBlock<StakingMinerConfig, ...>`
      --> tests/monitor.rs:97:40
```
Drop the local alias in favour of the one in `prelude`, which already tracks `Config`.

`ci.yml` never compiled this file: `check-code`, Clippy and test all run without `--features integration-tests`, so #1302 merged green and the breakage would only have surfaced in nightly.yml the next day.
Check it with `--all-features` in `check-code`. The default feature set stays covered by the build and test jobs, and the crate has no `cfg(not(feature = ...))`, so the all-features build is a superset for compile coverage.