### PR TITLE
fix(ci): install zombienet from release binary

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -55,8 +55,12 @@ jobs:
         with:
           node-version: "18"
 
-      - name: Install zombienet globally
-        run: npm install -g @zombienet/cli
+      - name: Install zombienet
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSfL \
+            https://github.com/paritytech/zombienet/releases/latest/download/zombienet-linux-x64 \
+            -o /usr/local/bin/zombienet
+          chmod +x /usr/local/bin/zombienet
 
       - name: Verify installations
         run: |


### PR DESCRIPTION
`npm install -g @zombienet/cli` resolves a dependency, which CI image's git can no longer fetch anonymously because github.com now **401**s its `protocol-v2` `POST` over `HTTP/2`, and npm falls back to ssh, which the image has no client for.

Fix #1322