### PR TITLE
workaround(ci): unbreak the nightly netcat install

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -48,6 +48,7 @@ jobs:
           # [TEMPORARY WORKAROUND] Debian 11 LTS ended on 2026-08-31, so
           # bullseye-security's Release file is expired and apt fails the whole update
           # over it. Until we bump to a new image, let's temporarily add `Check-Valid-Until=false` flag.
+          # TODO: remove once we have updated to a newer image.
           apt-get -o Acquire::Check-Valid-Until=false update
           apt-get install -y netcat-openbsd
           # Install just

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -41,9 +41,15 @@ jobs:
           path: polkadot-sdk
 
       - name: Install dependencies
+        shell: bash
         run: |
-          # Install netcat for port checking
-          apt-get update && apt-get install -y netcat
+          set -euo pipefail
+          # Install netcat for port checking.
+          # [TEMPORARY WORKAROUND] Debian 11 LTS ended on 2026-08-31, so
+          # bullseye-security's Release file is expired and apt fails the whole update
+          # over it. Until we bump to a new image, let's temporarily add `Check-Valid-Until=false` flag.
+          apt-get -o Acquire::Check-Valid-Until=false update
+          apt-get install -y netcat-openbsd
           # Install just
           curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
           # Install bun
@@ -67,6 +73,7 @@ jobs:
           zombienet --help
           just --version
           bun --version
+          command -v nc
 
       - name: Cache Rust dependencies for polkadot-sdk
         uses: swatinem/rust-cache@v2


### PR DESCRIPTION
Debian 11 LTS ended `2026-08-31`, `bullseye-security`'s Release file is inow  expired and `apt-get update` fails.

```
Reading package lists...
E: Release file for http://deb.debian.org/debian-security/dists/bullseye-security/InRelease is expired (invalid since 7h 43min 22s). Updates for this repository will not be applied.
```

causing test to fail because of 

```
> /tmp/just-inC80o/setup: line 26: nc: command not found
❌ Timeout waiting for port 9944
```

Until we bump to a new Debian image, skip the `Valid-Until` check in the verify step.

Testing the fix here: https://github.com/paritytech/polkadot-staking-miner/actions/runs/34205052146

```
Preparing to unpack .../netcat-openbsd_1.217-3_amd64.deb ...
Unpacking netcat-openbsd (1.217-3) ...
Setting up netcat-openbsd (1.217-3) ...
update-alternatives: using /bin/nc.openbsd to provide /bin/nc (nc) in auto mode
```

Close https://github.com/paritytech/polkadot-staking-miner/issues/1324.