### PR TITLE
Update ci-unified image to `bullseye-1.93.0-2026-01-27-v202609081126`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
       - main
 
 env:
-  IMAGE: docker.io/paritytech/ci-unified:bullseye-1.93.0-2026-01-27-v202603042356
+  IMAGE: docker.io/paritytech/ci-unified:bullseye-1.93.0-2026-01-27-v202609081126
   IMAGE_NAME: paritytech/polkadot-staking-miner
   RUST_INFO: rustup show && cargo --version && rustup +nightly show && cargo +nightly --version
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -44,7 +44,7 @@ jobs:
         shell: bash
         run: |
           # Install netcat for port checking
-          apt-get update && apt-get install -y netcat
+          apt-get update && apt-get install -y netcat-openbsd
           # Install just
           curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
           # Install bun

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -43,14 +43,8 @@ jobs:
       - name: Install dependencies
         shell: bash
         run: |
-          set -euo pipefail
-          # Install netcat for port checking.
-          # [TEMPORARY WORKAROUND] Debian 11 LTS ended on 2026-08-31, so
-          # bullseye-security's Release file is expired and apt fails the whole update
-          # over it. Until we bump to a new image, let's temporarily add `Check-Valid-Until=false` flag.
-          # TODO: remove once we have updated to a newer image.
-          apt-get -o Acquire::Check-Valid-Until=false update
-          apt-get install -y netcat-openbsd
+          # Install netcat for port checking
+          apt-get update && apt-get install -y netcat
           # Install just
           curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
           # Install bun

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 env:
-  IMAGE: docker.io/paritytech/ci-unified:bullseye-1.93.0-2026-01-27-v202603042356
+  IMAGE: docker.io/paritytech/ci-unified:bullseye-1.93.0-2026-01-27-v202609081126
   RUST_INFO: rustup show && cargo --version && rustup +nightly show && cargo +nightly --version
 
 jobs:


### PR DESCRIPTION
New bullseye ci-unified with temporary workaround for the expired `bullseye-security`

cc https://github.com/paritytech/devops/issues/5593